### PR TITLE
[DRAFT] fix: add ability to cancel, API not implemented on server W-17867176

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       label:
         description: Label for the generated vsix artifact
         required: false
-        default: EFDExtension-${{ github.sha }}
+        default: AFDXExtension-${{ github.sha }}
         type: string
 
 jobs:
@@ -25,8 +25,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      #      - name: Configure Git for private repo access
-      #        run: git config --global --add url."https://${{ secrets.IDEE_GH_TOKEN }}@github.com/".insteadOf "https://github.com/"
       - run: npm ci
       - run: npm --version
       - run: node --version


### PR DESCRIPTION
### What does this PR do?
adds `cancel` button to test progress notification

### What issues does this PR fix or reference?

@W-17867176@

### Functionality Before

no cancel button

### Functionality After

cancel button, that cancels tests in org


