### PR TITLE
chore: left align test case header W-17895899

### DIFF
--- a/src/views/testRunner.ts
+++ b/src/views/testRunner.ts
@@ -45,10 +45,8 @@ export class AgentTestRunner {
         testInfo.testCases = testInfo.testCases.filter(f => `#${f.testNumber}` === test.name);
       }
       testInfo.testCases.map(tc => {
-        const caseHeader = `CASE #${tc.testNumber} `;
-        const padding = new Array(36-caseHeader.length).fill(' ').join('')
         channelService.appendLine('════════════════════════════════════════════════════════════════════════');
-        channelService.appendLine(`${padding}${caseHeader}- ${testInfo.subjectName}`);
+        channelService.appendLine(`CASE #${tc.testNumber} - ${testInfo.subjectName}`);
         channelService.appendLine('════════════════════════════════════════════════════════════════════════');
         channelService.appendLine('');
         channelService.appendLine(`"${tc.inputs.utterance}"`);


### PR DESCRIPTION
@W-17895899@

from 
```
════════════════════════════════════════════════════════════════════════
                            CASE #1 - Local_Info_Agent_Test
════════════════════════════════════════════════════════════════════════
```
(in vscode, tab separators are highlighted)

to
```
════════════════════════════════════════════════════════════════════════
CASE #1 - GE_Agent_Test_Rebecca
════════════════════════════════════════════════════════════════════════
```

ignore different test name


<img width="424" alt="image" src="https://github.com/user-attachments/assets/ab7ea28c-fcf5-4a3a-aa3b-163256e1f326" />


