### PR TITLE
feat: support opening agents in MPD projects W-17961897

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/agents-bundle": "0.12.1",
-        "@salesforce/core-bundle": "8.8.2",
+        "@salesforce/core-bundle": "8.8.5",
         "cross-spawn": "^7.0.6",
         "fast-xml-parser": "^4.5.1",
         "semver": "^7.7.0",
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/@jsforce/jsforce-node": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.6.4.tgz",
-      "integrity": "sha512-9IZL5lFDE1nUnPYnzOleH0xaEE3Sc9sQcLKwx1LQeSyAI/KvnxySadlIpZAdTrJap4hDRFQkXiEFiJ3oFwj/zg==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.6.6.tgz",
+      "integrity": "sha512-WdIo2lLbrz6nkfiaz2UynyaNiM8o+fEjaRev7zA4KKSaQYB1MJ66xHubeI5Iheq8WgkY9XGwWKAwPDhuV+GROQ==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4",
@@ -2386,12 +2386,12 @@
       }
     },
     "node_modules/@salesforce/core-bundle": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/core-bundle/-/core-bundle-8.8.2.tgz",
-      "integrity": "sha512-AJPzAl5EO9FYvXmgYSAqH9dBIv0bLlQ+HKzwyiab5VbEM/cTGdoWGpNrL65E1xlTt51FktYdymgdUONfzlaStw==",
+      "version": "8.8.5",
+      "resolved": "https://registry.npmjs.org/@salesforce/core-bundle/-/core-bundle-8.8.5.tgz",
+      "integrity": "sha512-pauzleavYGoJmZQyRzGOwn8rbn2xPJM/cny6eeRSFwZkXqFbblhZY3LeOSec3tR4BNQBtFIUwDPbUN4nP849+g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@jsforce/jsforce-node": "^3.6.1",
+        "@jsforce/jsforce-node": "^3.6.5",
         "@salesforce/kit": "^3.2.2",
         "@salesforce/schemas": "^1.9.0",
         "@salesforce/ts-types": "^2.0.10",
@@ -2437,16 +2437,17 @@
       "license": "ISC"
     },
     "node_modules/@salesforce/source-deploy-retrieve-bundle": {
-      "version": "12.15.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve-bundle/-/source-deploy-retrieve-bundle-12.15.0.tgz",
-      "integrity": "sha512-VWRMWonZop5UEcqi0Wr8kLFuV8P0J4TAN9iYIEOHhbm3S1F7I6fXmpVAPXYE+avgb4bmEdt8Ym2jxCglP9PL2g==",
+      "version": "12.16.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve-bundle/-/source-deploy-retrieve-bundle-12.16.4.tgz",
+      "integrity": "sha512-gxXW3AC6Z5iAW0eFSj3cp+3nhxXTfnA8NEcJ6m+p8RNgLVeE5jJ88aKvIwuaAgLpbX1IEDYTqjJtSwcNYS/EAA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core-bundle": "^8.8.2",
+        "@salesforce/core-bundle": "^8.8.3",
         "@salesforce/kit": "^3.2.3",
         "@salesforce/ts-types": "^2.0.12",
+        "@salesforce/types": "^1.3.0",
         "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^4.5.1",
+        "fast-xml-parser": "^4.5.3",
         "got": "^11.8.6",
         "graceful-fs": "^4.2.11",
         "ignore": "^5.3.2",
@@ -2468,6 +2469,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@salesforce/types": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/types/-/types-1.3.0.tgz",
+      "integrity": "sha512-tcjBZrzCukOVIVm7mLHefsfDMyd+MTWWFWXk5wbdIQa+hiehUSA2SG0B0cpDMuOaIa9UiBm/SQCI+zznlt6W6g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
@@ -6812,22 +6822,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
-      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -11239,9 +11245,9 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
-      "integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -13319,9 +13325,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/agents-bundle": "0.12.1",
+        "@salesforce/agents-bundle": "0.13.0",
         "@salesforce/core-bundle": "8.8.5",
         "cross-spawn": "^7.0.6",
         "fast-xml-parser": "^4.5.1",
@@ -2369,15 +2369,15 @@
       }
     },
     "node_modules/@salesforce/agents-bundle": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/agents-bundle/-/agents-bundle-0.12.1.tgz",
-      "integrity": "sha512-PFiAoTuJs2k9XeaBNm1mcOWX9A2DHEUpZZOLNf92Zik0uPycI+gYwwrlsRYpVmLgrj6rYCXHvid92647WI1erw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/agents-bundle/-/agents-bundle-0.13.0.tgz",
+      "integrity": "sha512-lOQnXuqvrXJQ0As/IpXtKsKtHnnZ3c85Map/l2HZ8TGPiGcv8MCAbNIVFqWOyaZkcRVyCVwhIITC4jQq3pCDbA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core-bundle": "^8.8.2",
+        "@salesforce/core-bundle": "^8.8.5",
         "@salesforce/kit": "^3.2.3",
-        "@salesforce/source-deploy-retrieve-bundle": "^12.14.5",
-        "fast-xml-parser": "^4.5.1",
+        "@salesforce/source-deploy-retrieve-bundle": "^12.16.4",
+        "fast-xml-parser": "^4.5.3",
         "nock": "^13.5.6",
         "yaml": "^2.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "main": "lib/src/extension.js",
   "dependencies": {
-    "@salesforce/agents-bundle": "0.12.1",
+    "@salesforce/agents-bundle": "0.13.0",
     "@salesforce/core-bundle": "8.8.5",
     "cross-spawn": "^7.0.6",
     "fast-xml-parser": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "lib/src/extension.js",
   "dependencies": {
     "@salesforce/agents-bundle": "0.12.1",
-    "@salesforce/core-bundle": "8.8.2",
+    "@salesforce/core-bundle": "8.8.5",
     "cross-spawn": "^7.0.6",
     "fast-xml-parser": "^4.5.1",
     "semver": "^7.7.0",

--- a/src/commands/openAgentInOrg.ts
+++ b/src/commands/openAgentInOrg.ts
@@ -8,11 +8,14 @@ import { CoreExtensionService } from '../services/coreExtensionService';
 export const registerOpenAgentInOrgCommand = () => {
   return vscode.commands.registerCommand(Commands.openAgentInOrg, async () => {
     const telemetryService = CoreExtensionService.getTelemetryService();
+    const channelService = CoreExtensionService.getChannelService();
     telemetryService.sendCommandEvent(Commands.openAgentInOrg);
     const project = SfProject.getInstance();
     const agents = await Agent.list(project);
     if (agents.length === 0) {
       vscode.window.showErrorMessage(`Could not find agents in the current project.`);
+      channelService.appendLine('Could not find agents in the current project.');
+      channelService.appendLine('Suggestion: retrieve your agents (Bot) metadata locally.');
       return;
     }
     // we need to prompt the user which agent to ope

--- a/src/commands/openAgentInOrg.ts
+++ b/src/commands/openAgentInOrg.ts
@@ -1,27 +1,26 @@
 import * as vscode from 'vscode';
 import { Commands } from '../enums/commands';
 import { SfProject } from '@salesforce/core-bundle';
-import * as path from 'path';
+import { Agent } from '@salesforce/agents-bundle';
 import { sync } from 'cross-spawn';
 import { CoreExtensionService } from '../services/coreExtensionService';
 
 export const registerOpenAgentInOrgCommand = () => {
   return vscode.commands.registerCommand(Commands.openAgentInOrg, async () => {
-    // TODO: maybe an Agent.listLocal() or something similar in the library
     const telemetryService = CoreExtensionService.getTelemetryService();
     telemetryService.sendCommandEvent(Commands.openAgentInOrg);
     const project = SfProject.getInstance();
-    const defaultPath = project.getDefaultPackage().fullPath;
-    const agents = (
-      await vscode.workspace.fs.readDirectory(vscode.Uri.file(path.join(defaultPath, 'main', 'default', 'bots')))
-    ).map(f => f[0]);
-
+    const agents = await Agent.list(project);
+    if (agents.length === 0) {
+      vscode.window.showErrorMessage(`Could not find agents in the current project.`);
+      return;
+    }
     // we need to prompt the user which agent to ope
-    const agentName = await vscode.window.showQuickPick(agents, { title: 'Choose which Agent to open' });
+    const agentName = await vscode.window.showQuickPick(agents, { placeHolder: 'Agent name (type to search)' });
 
     if (!agentName) {
       telemetryService.sendException('no_agent_selected', 'No Agent selected');
-      throw new Error('No Agent selected');
+      return;
     }
 
     await vscode.window.withProgress(


### PR DESCRIPTION
### What issues does this PR fix or reference?
#### Updates the `Open an agent in default org` command to list all agents in the project dirs (defined in sfdx-project) 
instead of just the ones in the default project dir.
**DEPENDS ON**: https://github.com/forcedotcom/agents/pull/63/

#### Improve error if no agents are found locally
before:
![Screenshot 2025-03-04 at 13 22 49](https://github.com/user-attachments/assets/dc1fdc56-c0d1-46fc-bb6c-50b60e2c7d98)

after
![Screenshot 2025-03-04 at 16 05 52](https://github.com/user-attachments/assets/ee9c8a26-9f32-4379-bcb3-08f140704f64)

#### sets quickpick placeholder instead of title

![Screenshot 2025-03-04 at 16 07 32](https://github.com/user-attachments/assets/d8276f38-da0c-4d06-b3ff-9180ce80d87d)

https://code.visualstudio.com/api/ux-guidelines/quick-picks
> ❌ Don't
...
Use a title when the placeholder can describe the purpose on its own
...

@W-17961897@

### Testing Setup Notes

1. checkout this PR and bump `@salesforce/agents-bundle@dev` to get these changes: https://github.com/forcedotcom/agents/pull/63
2. compile
3. try the `open agent command` in projects with/without agents.

coral-cloud is an MPD project with agents: https://github.com/trailheadapps/coral-cloud

TODO:
DONE ✅ 
from Gordon:
> ~~Error should also be sent to the output channel for the extension.  See the ChannelService and usage for examples https://github.com/forcedotcom/salesforcedx-vscode-einstein-gpt/blob/a56e3ae2912586e357f6f9f2b4d0a5f2520b2cd2/src/services/CoreExtensionService.ts#L109~~