### PR TITLE
fix: warn user if no test results are available W-17985848

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
           "group": "inline"
         },
         {
-          "command": "sf.agent.test.view.goToDefinition",
+          "command": "sf.agent.test.view.goToTestResults",
           "when": "view == sf.agent.test.view && viewItem =~ /(agentTest|agentTestGroup)(_Pass|_Skip|\\b)/"
         }
       ],
@@ -154,7 +154,7 @@
     },
     "commandPalette": [
       {
-        "command": "sf.agent.test.view.goToDefinition",
+        "command": "sf.agent.test.view.goToTestResults",
         "when": "false"
       },
       {
@@ -180,8 +180,8 @@
     ],
     "commands": [
       {
-        "command": "sf.agent.test.view.goToDefinition",
-        "title": "%go_to_definition_title%",
+        "command": "sf.agent.test.view.goToTestResults",
+        "title": "%go_to_test_results%",
         "icon": {
           "light": "resources/light/notRun.svg",
           "dark": "resources/dark/notRun.svg"

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,6 @@
   "run_all_tests_title": "Run All Test Definitions",
   "run_test_title": "Run Test Definition",
   "refresh_test_title": "Refresh Test Definitions",
-  "go_to_definition_title": "View Test Definition",
+  "go_to_test_results": "AFDX: View Test Results",
   "collapse_tests_title": "Collapse All Test Cases"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,6 @@
   "run_all_tests_title": "Run All Test Definitions",
   "run_test_title": "Run Test Definition",
   "refresh_test_title": "Refresh Test Definitions",
-  "go_to_test_results": "AFDX: View Test Results",
+  "go_to_test_results": "SFDX: View Test Results",
   "collapse_tests_title": "Collapse All Test Cases"
 }

--- a/src/enums/commands.ts
+++ b/src/enums/commands.ts
@@ -1,6 +1,6 @@
 export enum Commands {
   openAgentInOrg = 'salesforcedx-vscode-agents.openAgentInOrg',
-  goToDefinition = 'sf.agent.test.view.goToDefinition',
+  goToTestResults = 'sf.agent.test.view.goToTestResults',
   runTest = 'sf.agent.test.view.runTest',
   refreshTestView = 'sf.agent.test.view.refresh',
   collapseAll = 'sf.agent.test.view.collapseAll'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ const registerTestView = (): vscode.Disposable => {
   const testRunner = new AgentTestRunner(testOutlineProvider);
 
   testViewItems.push(
-    vscode.commands.registerCommand(Commands.goToDefinition, (test: TestNode) => {
+    vscode.commands.registerCommand(Commands.goToTestResults, (test: TestNode) => {
       testRunner.displayTestDetails(test);
     })
   );

--- a/src/types/TestNodes.ts
+++ b/src/types/TestNodes.ts
@@ -25,7 +25,7 @@ export abstract class TestNode extends vscode.TreeItem {
   ) {
     super(name, collapsibleState);
     this.command = {
-      command: `sf.agent.test.view.goToDefinition`,
+      command: `sf.agent.test.view.goToTestResults`,
       title: 'SHOW ERROR',
       arguments: [this]
     };

--- a/src/views/testRunner.ts
+++ b/src/views/testRunner.ts
@@ -24,36 +24,38 @@ export class AgentTestRunner {
     channelService.clear();
 
     const resultFromMap = this.testGroupNameToResult.get(test.name) ?? this.testGroupNameToResult.get(test.parentName);
-    if (resultFromMap) {
-      // set to a new var so we can remove test cases and not affect saved information
-      const testInfo = structuredClone(resultFromMap);
-      if (test instanceof AgentTestNode) {
-        // filter to selected test case
-        testInfo.testCases = testInfo.testCases.filter(f => `#${f.testNumber}` === test.name);
-      }
-      testInfo.testCases.map(tc => {
-        channelService.appendLine('════════════════════════════════════════════════════════════════════════');
-        channelService.appendLine(`CASE #${tc.testNumber} - ${testInfo.subjectName}`);
-        channelService.appendLine('════════════════════════════════════════════════════════════════════════');
-        channelService.appendLine('');
-        channelService.appendLine(`"${tc.inputs.utterance}"`);
-        channelService.appendLine('');
-        tc.testResults.map(tr => {
-          channelService.appendLine(
-            `❯ ${humanFriendlyName(tr.name).toUpperCase()}: ${tr.result} ${tr.result === 'PASS' ? '✅' : '❌'}`
-          );
-          channelService.appendLine('────────────────────────────────────────────────────────────────────────');
-          channelService.appendLine(`EXPECTED : ${tr.expectedValue.replaceAll('\n', '')}`);
-          channelService.appendLine(`ACTUAL   : ${tr.actualValue.replaceAll('\n', '')}`);
-          channelService.appendLine(`SCORE    : ${tr.score}`);
-          channelService.appendLine('');
-        });
-        channelService.appendLine('────────────────────────────────────────────────────────────────────────');
-        channelService.appendLine(
-          `TEST CASE SUMMARY: ${tc.testResults.length} tests run | ✅ ${tc.testResults.filter(tc => tc.result === 'PASS').length} passed | ❌ ${tc.testResults.filter(tc => tc.result === 'FAILURE').length} failed`
-        );
-      });
+    if (!resultFromMap) {
+      vscode.window.showErrorMessage('You need to run the test first to see its results.');
+      return;
     }
+    // set to a new var so we can remove test cases and not affect saved information
+    const testInfo = structuredClone(resultFromMap);
+    if (test instanceof AgentTestNode) {
+      // filter to selected test case
+      testInfo.testCases = testInfo.testCases.filter(f => `#${f.testNumber}` === test.name);
+    }
+    testInfo.testCases.map(tc => {
+      channelService.appendLine('════════════════════════════════════════════════════════════════════════');
+      channelService.appendLine(`CASE #${tc.testNumber} - ${testInfo.subjectName}`);
+      channelService.appendLine('════════════════════════════════════════════════════════════════════════');
+      channelService.appendLine('');
+      channelService.appendLine(`"${tc.inputs.utterance}"`);
+      channelService.appendLine('');
+      tc.testResults.map(tr => {
+        channelService.appendLine(
+          `❯ ${humanFriendlyName(tr.name).toUpperCase()}: ${tr.result} ${tr.result === 'PASS' ? '✅' : '❌'}`
+        );
+        channelService.appendLine('────────────────────────────────────────────────────────────────────────');
+        channelService.appendLine(`EXPECTED : ${tr.expectedValue.replaceAll('\n', '')}`);
+        channelService.appendLine(`ACTUAL   : ${tr.actualValue.replaceAll('\n', '')}`);
+        channelService.appendLine(`SCORE    : ${tr.score}`);
+        channelService.appendLine('');
+      });
+      channelService.appendLine('────────────────────────────────────────────────────────────────────────');
+      channelService.appendLine(
+        `TEST CASE SUMMARY: ${tc.testResults.length} tests run | ✅ ${tc.testResults.filter(tc => tc.result === 'PASS').length} passed | ❌ ${tc.testResults.filter(tc => tc.result === 'FAILURE').length} failed`
+      );
+    });
   }
 
   public async runAgentTest(test: AgentTestGroupNode) {


### PR DESCRIPTION
### What does this PR do?
Adds a error message if trying to go to test results and no tests ran.

### Why?
I was clicking on this `View Test Definition` context menu command, thinking it would open the XML file but instead it's the same command when you click on the test (opens console `Output` and the specific test results.

<img width="735" alt="Screenshot 2025-03-06 at 19 32 22" src="https://github.com/user-attachments/assets/7d6f296b-ce06-4f50-99b3-b49a7fa35622" />

#### Questions:
* DONE ✅ ~~should we rename this command to better communicate its intent? also, add a category so we know it's from the AFDX extension (`AFDX: View Test Definition` instead of `View Test Definition`)~~

### What issues does this PR fix or reference?

@W-17985848@

### Functionality Before

Clicking on a test/context menu would do nothing if no tests ran before

### Functionality After

If no tests data from a previous run, point the user to run them!

<img width="1728" alt="Screenshot 2025-03-06 at 19 34 13" src="https://github.com/user-attachments/assets/82872422-1616-4896-a6f9-be7080874e28" />

### Testing Setup Notes

<insert helpful notes to help your QE get started>
