### PR TITLE
fix: remove `View Test Results` from command palette W-17990172

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,12 @@
       ]
     },
     "menus": {
+      "commandPalette": [
+        {
+          "command": "sf.agent.test.view.goToTestResults",
+          "when": "false"
+        }
+      ],
       "view/title": [
         {
           "command": "sf.agent.test.view.runAll",
@@ -154,10 +160,6 @@
     },
     "commandPalette": [
       {
-        "command": "sf.agent.test.view.goToTestResults",
-        "when": "false"
-      },
-      {
         "command": "salesforcedx-vscode-agents.openAgentInOrg",
         "when": "resourceFilename =~ /.*\\.bot-meta\\.xml/ || resourceFilename =~ /.*\\.botVersion-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml/"
       },
@@ -181,11 +183,7 @@
     "commands": [
       {
         "command": "sf.agent.test.view.goToTestResults",
-        "title": "%go_to_test_results%",
-        "icon": {
-          "light": "resources/light/notRun.svg",
-          "dark": "resources/dark/notRun.svg"
-        }
+        "title": "%go_to_test_results%"
       },
       {
         "command": "sf.agent.test.view.refresh",


### PR DESCRIPTION
### What does this PR do?
Removes `SFDX: View Test Results` from the command palette, it's expected to receive a test item when called via the context menu so it fails with a `Cannot read properties of undefined ...` when called from command palette.

### What issues does this PR fix or reference?
@W-17990172@

### Functionality Before

`SFDX: View Test Results` is accessible in command palette, running it would throw an error:
![Screenshot 2025-03-07 at 19 02 45](https://github.com/user-attachments/assets/9835a249-afc7-4090-93bb-a9894b76d7e5)
![Screenshot 2025-03-07 at 19 03 07](https://github.com/user-attachments/assets/70ec2c72-3842-4e14-81bb-dc34e33ef857)

### Functionality After
`SFDX: View Test Results` is only available as a context menu command:
![Screenshot 2025-03-07 at 19 07 22](https://github.com/user-attachments/assets/fb84ea17-d913-4f92-8491-8ffd7ce89348)
![Screenshot 2025-03-07 at 19 07 53](https://github.com/user-attachments/assets/34e1761d-9ab5-40f1-9eea-158de5be68e3)

### Testing Setup Notes
