### PR TITLE
fix: keep the test summary when clicking on the parent in the tree @W-18725330@

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "salesforcedx-vscode-agents",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "salesforcedx-vscode-agents",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/agents-bundle": "^0.14.11",


### PR DESCRIPTION
### What does this PR do?
The only time you could see the test run id, and quick resutls was right after the test finished, and before clicking on anything in the tree,

now if you click on the parent, you get the test summary again

### What issues does this PR fix or reference?

@W-18725330@

### Functionality Before

no way to get test run id back

### Functionality After

test summary 
