### PR TITLE
fix: add verbose toggle @W-19345325@

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,16 @@
     "workspaceContains:sfdx-project.json"
   ],
   "contributes": {
+    "configuration": {
+      "title": "Agentforce DX",
+      "properties": {
+        "agentforceDX.showGeneratedData": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show generated data in test results output"
+        }
+      }
+    },
     "views": {
       "test": [
         {
@@ -139,6 +149,16 @@
           "command": "sf.agent.test.view.collapseAll",
           "when": "view == sf.agent.test.view",
           "group": "navigation@3"
+        },
+        {
+          "command": "sf.agent.test.view.toggleGeneratedData.on",
+          "when": "view == sf.agent.test.view && agentforceDX:showGeneratedData",
+          "group": "navigation@4"
+        },
+        {
+          "command": "sf.agent.test.view.toggleGeneratedData.off",
+          "when": "view == sf.agent.test.view && !agentforceDX:showGeneratedData",
+          "group": "navigation@4"
         }
       ],
       "view/item/context": [
@@ -238,6 +258,7 @@
           "dark": "resources/dark/collapse-all.svg"
         }
       },
+
       {
         "command": "sf.agent.test.view.runAll",
         "title": "%run_all_tests_title%",
@@ -265,6 +286,24 @@
       {
         "command": "salesforcedx-vscode-agents.deactivateAgent",
         "title": "%salesforcedx-vscode-agents.deactivateAgent%"
+      },
+      {
+        "command": "sf.agent.test.view.toggleGeneratedData.on",
+        "title": "Hide Generated Data Output",
+        "category": "Agent Tests",
+        "icon": {
+          "light": "resources/light/check-on.svg",
+          "dark": "resources/dark/check-on.svg"
+        }
+      },
+      {
+        "command": "sf.agent.test.view.toggleGeneratedData.off",
+        "title": "Show Generated Data Output",
+        "category": "Agent Tests",
+        "icon": {
+          "light": "resources/light/check-off.svg",
+          "dark": "resources/dark/check-off.svg"
+        }
       }
     ]
   }

--- a/resources/dark/check-off.svg
+++ b/resources/dark/check-off.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path fill="#C5C5C5" d="M14 1H2C1.45 1 1 1.45 1 2v12c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm-1 12H3V3h10v10z"/>
+</svg>

--- a/resources/dark/check-on.svg
+++ b/resources/dark/check-on.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path fill="#C5C5C5" d="M14 3.5L5.5 12 2 8.5l1-1L5.5 10 13 2.5z"/>
+</svg>

--- a/resources/light/check-off.svg
+++ b/resources/light/check-off.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path fill="#424242" d="M14 1H2C1.45 1 1 1.45 1 2v12c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm-1 12H3V3h10v10z"/>
+</svg>

--- a/resources/light/check-on.svg
+++ b/resources/light/check-on.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path fill="#424242" d="M14 3.5L5.5 12 2 8.5l1-1L5.5 10 13 2.5z"/>
+</svg>

--- a/src/commands/toggleGeneratedData.ts
+++ b/src/commands/toggleGeneratedData.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ **/
+import * as vscode from 'vscode';
+
+/**
+ * Toggles the visibility of generated data in test results
+ */
+/**
+ * Updates the generated data visibility setting and triggers a configuration change event
+ */
+async function updateGeneratedDataSetting(value: boolean): Promise<void> {
+  const config = vscode.workspace.getConfiguration('agentforceDX');
+  await config.update('showGeneratedData', value, vscode.ConfigurationTarget.Global);
+}
+
+export async function toggleGeneratedDataOn(): Promise<void> {
+  await updateGeneratedDataSetting(true);
+}
+
+export async function toggleGeneratedDataOff(): Promise<void> {
+  await updateGeneratedDataSetting(false);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import * as commands from './commands';
 import { getTestOutlineProvider } from './views/testOutlineProvider';
 import { AgentTestRunner } from './views/testRunner';
 import { Commands } from './enums/commands';
+import { toggleGeneratedDataOn, toggleGeneratedDataOff } from './commands/toggleGeneratedData';
 import type { AgentTestGroupNode, TestNode } from './types';
 import { CoreExtensionService } from './services/coreExtensionService';
 import type { TelemetryService } from './types/TelemetryService';
@@ -37,7 +38,7 @@ export async function activate(context: vscode.ExtensionContext) {
     disposables.push(commands.registerOpenAgentInOrgCommand());
     disposables.push(commands.registerActivateAgentCommand());
     disposables.push(commands.registerDeactivateAgentCommand());
-    context.subscriptions.push(registerTestView());
+    context.subscriptions.push(await registerTestView());
 
     // Update the test view without blocking activation
     setTimeout(() => getTestOutlineProvider().refresh(), 0);
@@ -49,7 +50,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 }
 
-const registerTestView = (): vscode.Disposable => {
+const registerTestView = async (): Promise<vscode.Disposable> => {
   const testOutlineProvider = getTestOutlineProvider();
   const testViewItems: vscode.Disposable[] = [];
 
@@ -71,6 +72,35 @@ const registerTestView = (): vscode.Disposable => {
   testViewItems.push(vscode.commands.registerCommand(Commands.refreshTestView, () => testOutlineProvider.refresh()));
 
   testViewItems.push(vscode.commands.registerCommand(Commands.collapseAll, () => testOutlineProvider.collapseAll()));
+
+  // Initialize generated data context based on current setting
+  const updateGeneratedDataContext = async () => {
+    const config = vscode.workspace.getConfiguration('agentforceDX');
+    const showGeneratedData = config.get<boolean>('showGeneratedData', false);
+    await vscode.commands.executeCommand('setContext', 'agentforceDX:showGeneratedData', showGeneratedData);
+  };
+
+  // Listen for configuration changes
+  testViewItems.push(
+    vscode.workspace.onDidChangeConfiguration(async (e) => {
+      if (e.affectsConfiguration('agentforceDX.showGeneratedData')) {
+        await updateGeneratedDataContext();
+      }
+    })
+  );
+
+  // Set initial context
+  await updateGeneratedDataContext();
+
+  // Register commands to toggle generated data visibility
+  testViewItems.push(
+    vscode.commands.registerCommand('sf.agent.test.view.toggleGeneratedData.on', async () => {
+      await toggleGeneratedDataOff(); // Switch to off when clicking the "on" icon
+    }),
+    vscode.commands.registerCommand('sf.agent.test.view.toggleGeneratedData.off', async () => {
+      await toggleGeneratedDataOn(); // Switch to on when clicking the "off" icon
+    })
+  );
 
   return vscode.Disposable.from(...testViewItems);
 };

--- a/src/views/testRunner.ts
+++ b/src/views/testRunner.ts
@@ -77,8 +77,9 @@ export class AgentTestRunner {
           channelService.appendLine('');
         });
 
-      // it's not a real string[], more like just a string  "[&#39;IdentifyRecordByName&#39;]", so "[]", empty, is 2 characters
-      if (tc.generatedData?.actionsSequence?.length > 2) {
+      // Show generated data only if enabled in settings
+      const showGeneratedData = vscode.workspace.getConfiguration('agentforceDX').get<boolean>('showGeneratedData');
+      if (showGeneratedData && tc.generatedData?.actionsSequence?.length > 2) {
         channelService.appendLine('❯ ACTION: INVOCATION ℹ️');
         channelService.appendLine('────────────────────────────────────────────────────────────────────────');
         channelService.appendLine(


### PR DESCRIPTION
### What does this PR do?
adds a button in the tree , and a setting, to show or hide the generatedData output in the panel

### What issues does this PR fix or reference?

 @W-19345325@

### Functionality Before
always printing generated data output


### Functionality After

<img width="281" height="117" alt="image" src="https://github.com/user-attachments/assets/37d20e2e-3ec2-44e5-b3d9-821f9c8812f6" />
<img width="131" height="52" alt="image" src="https://github.com/user-attachments/assets/e4fba952-982d-4ea4-ab18-a0036fbb54ba" />

optionally prints output


### Testing Setup Notes
have a test that generates data via invoked action
