### PR TITLE
Wr/add validate af script @W-19293903@

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "salesforcedx-vscode-agents",
       "version": "1.2.0",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/agents": "^0.17.7",
+        "@salesforce/agents": "^0.17.10",
         "@salesforce/core": "^8.22.0",
         "@salesforce/types": "^1.3.0",
         "cross-spawn": "^7.0.6",
@@ -2362,10 +2362,9 @@
       }
     },
     "node_modules/@salesforce/agents": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@salesforce/agents/-/agents-0.17.7.tgz",
-      "integrity": "sha512-kPdc4M3n1tQGrfbt4pN3E7b0O7wV3FyZ6Wc26aKYI+rsWREzVDl4hRiRMbC3qSAQNdP+pF1E4p/Tsfjduy86Ig==",
-      "license": "BSD-3-Clause",
+      "version": "0.17.10",
+      "resolved": "https://registry.npmjs.org/@salesforce/agents/-/agents-0.17.10.tgz",
+      "integrity": "sha512-KgBeOGXkLTshtYkOEXbTbTsuZkKPjhQkz6bgf5sjyoX2Op5vie+jZc/lGg5dqq7mZdAkmtezHefEpwkcyYTLsg==",
       "dependencies": {
         "@salesforce/core": "^8.19.1",
         "@salesforce/kit": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "lib/src/extension.js",
   "dependencies": {
-    "@salesforce/agents": "^0.17.7",
+    "@salesforce/agents": "^0.17.10",
     "@salesforce/core": "^8.22.0",
     "@salesforce/types": "^1.3.0",
     "cross-spawn": "^7.0.6",
@@ -200,9 +200,14 @@
       ],
       "editor/context": [
         {
+          "command": "salesforcedx-vscode-agents.validateAfScript",
+          "when": "resourceFilename =~ /.*\\.afscript$/",
+          "group": "agent@1"
+        },
+        {
           "command": "salesforcedx-vscode-agents.openAgentInOrg",
           "when": "resourceFilename =~ /.*\\.bot-meta\\.xml$/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ ||  resourceFilename =~ /.*\\.botVersion-meta\\.xml$/ || resourceFilename =~ /.*Planner\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml$/",
-          "group": "agent@1"
+          "group": "agent@2"
         },
         {
           "command": "salesforcedx-vscode-agents.activateAgent",
@@ -217,9 +222,14 @@
       ],
       "explorer/context": [
         {
+          "command": "salesforcedx-vscode-agents.validateAfScript",
+          "when": "resourceFilename =~ /.*\\.afscript$/",
+          "group": "agent@1"
+        },
+        {
           "command": "salesforcedx-vscode-agents.openAgentInOrg",
           "when": "resourceFilename =~ /.*\\.bot-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlannerBundle/ || resourceFilename =~ /.*\\.botVersion-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml/",
-          "group": "agent@1"
+          "group": "agent@2"
         },
         {
           "command": "salesforcedx-vscode-agents.activateAgent",
@@ -233,6 +243,10 @@
         }
       ],
       "commandPalette": [
+        {
+          "command": "salesforcedx-vscode-agents.validateAfScript",
+          "when": "resourceFilename =~ /.*\\.afscript$/"
+        },
         {
           "command": "sf.agent.test.view.goToTestResults",
           "when": "false"
@@ -364,6 +378,10 @@
           "light": "resources/light/check-off.svg",
           "dark": "resources/dark/check-off.svg"
         }
+      },
+      {
+        "command": "salesforcedx-vscode-agents.validateAfScript",
+        "title": "AFDX: Validate AFscript"
       }
     ]
   }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,4 @@
 export * from './openAgentInOrg';
 export * from './activateAgent';
 export * from './deactivateAgent';
+export * from './validateAfScript';

--- a/src/commands/validateAfScript.ts
+++ b/src/commands/validateAfScript.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { Commands } from '../enums/commands';
+import { Agent } from '@salesforce/agents';
+import { CoreExtensionService } from '../services/coreExtensionService';
+import { SfError } from '@salesforce/core';
+
+export const registerValidateAfScriptCommand = () => {
+  return vscode.commands.registerCommand(Commands.validateAfScript, async (uri?: vscode.Uri) => {
+    const telemetryService = CoreExtensionService.getTelemetryService();
+    const channelService = CoreExtensionService.getChannelService();
+    telemetryService.sendCommandEvent(Commands.validateAfScript);
+
+    // Get the file path from the context menu
+    const filePath = uri?.fsPath || vscode.window.activeTextEditor?.document.fileName;
+
+    if (!filePath) {
+      vscode.window.showErrorMessage('No .afscript file selected.');
+      return;
+    }
+
+      try {
+        // Read the file contents
+      const fileContents = Buffer.from((await vscode.workspace.fs.readFile(vscode.Uri.file(filePath)))).toString();
+
+      // Attempt to compile the AF Script
+      try {
+        await Agent.compileAfScript(await CoreExtensionService.getDefaultConnection(), fileContents);
+        vscode.window.showInformationMessage('AF Script validation successful! 🎉');
+      } catch (compileError) {
+        const error = SfError.wrap(compileError);
+        // Show the output channel
+        channelService.showChannelOutput();
+        channelService.clear();
+        // Show error details in output
+        channelService.appendLine('❌ AF Script validation failed!');
+        channelService.appendLine('────────────────────────────────────────────────────────────────────────');
+        channelService.appendLine(`Error: ${error.message}`);
+      }
+    } catch (e) {
+      const error = SfError.wrap(e);
+      
+      // Show file read error details
+      channelService.appendLine('❌ Error reading .afscript file!');
+      channelService.appendLine('');
+      channelService.appendLine('Error Details:');
+      channelService.appendLine('────────────────────────────────────────────────────────────────────────');
+      channelService.appendLine(`Error: ${error.message}`);
+      
+      if (error.stack) {
+        channelService.appendLine('');
+        channelService.appendLine('Stack Trace:');
+        channelService.appendLine('────────────────────────────────────────────────────────────────────────');
+        channelService.appendLine(error.stack);
+      }
+    }
+  });
+};

--- a/src/enums/commands.ts
+++ b/src/enums/commands.ts
@@ -2,6 +2,7 @@ export enum Commands {
   openAgentInOrg = 'salesforcedx-vscode-agents.openAgentInOrg',
   activateAgent = 'salesforcedx-vscode-agents.activateAgent',
   deactivateAgent = 'salesforcedx-vscode-agents.deactivateAgent',
+  validateAfScript = 'salesforcedx-vscode-agents.validateAfScript',
   goToTestResults = 'sf.agent.test.view.goToTestResults',
   runTest = 'sf.agent.test.view.runTest',
   refreshTestView = 'sf.agent.test.view.refresh',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
     disposables.push(commands.registerOpenAgentInOrgCommand());
     disposables.push(commands.registerActivateAgentCommand());
     disposables.push(commands.registerDeactivateAgentCommand());
+    disposables.push(commands.registerValidateAfScriptCommand());
     context.subscriptions.push(await registerTestView());
     context.subscriptions.push(registerAgentCombinedView(context));
 


### PR DESCRIPTION
### NOTE:

original PR https://github.com/forcedotcom/vscode-agents/pull/65 was merged, and reverted https://github.com/forcedotcom/vscode-agents/pull/66

---

this PR reopens the original changes, which have all been approved and merged once-before

What does this PR do?
adds an AFDX: validate afscript context option to .afscript files
<img width="1402" height="1002" alt="image" src="https://github.com/user-attachments/assets/a4504002-ce95-4b86-b7fd-e34b0ec2631c" />


What issues does this PR fix or reference?
@W-19293903@

Functionality Before
no NGA functionality

Functionality After
able to quickly validate afScript via server-side compile

Testing Setup Notes
get the built vsix from the clicking on the green checkmark by the commit hash, select build-and-test, click on summary in the upper left, scroll to the bottom for the vsix, installing this, and setting SF_MOCK_DIR should work as well

using maybe-mock in the development extension host session is overly complicated. I found the best approach was to change vscode-agents/node_modules/@salesforce/agents/lib/agent.js Line 323 to be

        const response = JSON.parse(await (0, promises_1.readFile)('YOUR/PATH/TO/agents/test/mocks/einstein_ai-agent_v1.1_authoring_compile.json', 'utf-8'));
and an example failure response,

{
  "status": "failure",
  "errors": [{
    "errorType": "ISSUE",
    "description": "couldn't compile this",
    "colStart": 1,
    "colEnd": 2,
    "lineStart": 1,
    "lineEnd": 1
  },
    {
      "errorType": "ISSUE123",
      "description": "testing error 2",
      "colStart": 12,
      "colEnd": 22,
      "lineStart": 12,
      "lineEnd": 12
    }],
Note: there's an error property already in the mock, you just need to place those correctly and update the status for a failure response