### PR TITLE
fix: update metric scoring range/threshold output @W-19751054@

### DIFF
--- a/src/views/testRunner.ts
+++ b/src/views/testRunner.ts
@@ -103,8 +103,8 @@ export class AgentTestRunner {
             );
           } else {
             channelService.appendLine(
-              // 0.6 is the threshold for passing, hardcoded for now
-              `${tr.result === 'PASS' ? '✅' : '❌'} : ${humanFriendlyName(tr.name).toUpperCase()} (${tr.score}/0.6) ${tr.metricExplainability ? `: ${tr.metricExplainability}` : ''}`
+              // 3 is the threshold for passing, hardcoded for now
+              `${tr.result === 'PASS' ? '✅' : '❌'} : ${humanFriendlyName(tr.name).toUpperCase()} (${tr.score}/3) ${tr.metricExplainability ? `: ${tr.metricExplainability}` : ''}`
             );
           }
         });


### PR DESCRIPTION
### What does this PR do?
metric score values are changing from 0-1 to 0 or 1 to 5 based on the metric

this updates the output so the result makes sense `(2/4)` instead of `(2/0.6)`

### What issues does this PR fix or reference?

@W-19751054@

### Functionality Before
```
✅ : COMPLETENESS (4/0.6) : The answer covers most of the desired content, including the account overview, opportunities, open cases, activity, and contacts. However, it misses some details such as the account's location, industry, and the sum amount in the open pipeline.
✅ : COHERENCE (4/0.6) : The answer is easy to understand, free of significant grammar errors, and flows well when read by itself. The answer provides a clear summary of the Acme account, including its industry, number of employees, annual revenue, account manager, open pipeline, opportunities, open cases, activity, key contacts, and recent purchases. The answer is well-organized and easy to follow.
❌ : CONCISENESS (0/0.6) 
```

### Functionality After

```
✅ : COMPLETENESS (4/5) : The answer covers most of the desired content, including the account overview, opportunities, open cases, activity, and contacts. However, it misses some details such as the account's location, industry, and the sum amount in the open pipeline.
✅ : COHERENCE (4/5) : The answer is easy to understand, free of significant grammar errors, and flows well when read by itself. The answer provides a clear summary of the Acme account, including its industry, number of employees, annual revenue, account manager, open pipeline, opportunities, open cases, activity, key contacts, and recent purchases. The answer is well-organized and easy to follow.
❌ : CONCISENESS (0/5) 
```

### Testing Setup Notes

run a test with metrics defined in the aiEval def
```xml
        <expectation>
            <name>coherence</name>
        </expectation>
        <expectation>
            <name>conciseness</name>
        </expectation>
```
