### PR TITLE
Wr/preview af script demo @W-19775417@

### DIFF
--- a/agent-chat-and-trace/src/components/AgentPreview/AgentSelector.tsx
+++ b/agent-chat-and-trace/src/components/AgentPreview/AgentSelector.tsx
@@ -21,13 +21,27 @@ const AgentSelector: React.FC<AgentSelectorProps> = ({
 
   useEffect(() => {
     // Listen for available agents from VS Code
-    vscodeApi.onMessage('availableAgents', (data: AgentInfo[]) => {
+    vscodeApi.onMessage('availableAgents', (data: { agents: AgentInfo[], selectedAgentId?: string } | AgentInfo[]) => {
       setIsLoading(false);
-      if (data && data.length > 0) {
-        setAgents(data);
-        // Don't automatically select or start session - wait for user selection
+      if (Array.isArray(data)) {
+        // Handle legacy format
+        if (data.length > 0) {
+          setAgents(data);
+        } else {
+          setAgents([]);
+        }
       } else {
-        setAgents([]);
+        // Handle new format with selectedAgentId
+        if (data.agents && data.agents.length > 0) {
+          setAgents(data.agents);
+          if (data.selectedAgentId) {
+            onAgentChange(data.selectedAgentId);
+            // Start session with preselected agent
+            vscodeApi.startSession(data.selectedAgentId);
+          }
+        } else {
+          setAgents([]);
+        }
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -205,6 +205,11 @@
           "group": "agent@1"
         },
         {
+          "command": "salesforcedx-vscode-agents.previewAfScript",
+          "when": "resourceFilename =~ /.*\\.afscript$/",
+          "group": "agent@1"
+        },
+        {
           "command": "salesforcedx-vscode-agents.openAgentInOrg",
           "when": "resourceFilename =~ /.*\\.bot-meta\\.xml$/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ ||  resourceFilename =~ /.*\\.botVersion-meta\\.xml$/ || resourceFilename =~ /.*Planner\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml$/",
           "group": "agent@2"
@@ -227,6 +232,11 @@
           "group": "agent@1"
         },
         {
+          "command": "salesforcedx-vscode-agents.previewAfScript",
+          "when": "resourceFilename =~ /.*\\.afscript$/",
+          "group": "agent@1"
+        },
+        {
           "command": "salesforcedx-vscode-agents.openAgentInOrg",
           "when": "resourceFilename =~ /.*\\.bot-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlannerBundle/ || resourceFilename =~ /.*\\.botVersion-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml/",
           "group": "agent@2"
@@ -245,6 +255,10 @@
       "commandPalette": [
         {
           "command": "salesforcedx-vscode-agents.validateAfScript",
+          "when": "resourceFilename =~ /.*\\.afscript$/"
+        },
+        {
+          "command": "salesforcedx-vscode-agents.previewAfScript",
           "when": "resourceFilename =~ /.*\\.afscript$/"
         },
         {
@@ -308,6 +322,10 @@
       }
     ],
     "commands": [
+      {
+        "command": "salesforcedx-vscode-agents.previewAfScript",
+        "title": "AFDX: Preview Afscript"
+      },
       {
         "command": "sf.agent.test.view.goToTestResults",
         "title": "%go_to_test_results%"

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,3 +2,4 @@ export * from './openAgentInOrg';
 export * from './activateAgent';
 export * from './deactivateAgent';
 export * from './validateAfScript';
+export * from './previewAfScript';

--- a/src/commands/previewAfScript.ts
+++ b/src/commands/previewAfScript.ts
@@ -1,0 +1,88 @@
+import * as vscode from 'vscode';
+import { Commands } from '../enums/commands';
+import { Agent } from '@salesforce/agents';
+import { CoreExtensionService } from '../services/coreExtensionService';
+import { SfError } from '@salesforce/core';
+import { AgentCombinedViewProvider } from '../views/agentCombinedViewProvider';
+
+export const registerPreviewAfScriptCommand = () => {
+  return vscode.commands.registerCommand(Commands.previewAfScript, async (uri?: vscode.Uri) => {
+    const telemetryService = CoreExtensionService.getTelemetryService();
+    const channelService = CoreExtensionService.getChannelService();
+    telemetryService.sendCommandEvent(Commands.previewAfScript);
+
+    // Get the file path from the context menu
+    const filePath = uri?.fsPath || vscode.window.activeTextEditor?.document.fileName;
+
+    if (!filePath) {
+      vscode.window.showErrorMessage('No .afscript file selected.');
+      return;
+    }
+
+    try {
+      // Get the demo agent developer name from environment variable
+      const demoAgentName = process.env.SF_DEMO_AGENT;
+      if (!demoAgentName) {
+        vscode.window.showErrorMessage('SF_DEMO_AGENT environment variable not set. Please set it to the developer name of an agent to preview.');
+        return;
+      }
+
+      // Get connection and find the agent ID
+      const conn = await CoreExtensionService.getDefaultConnection();
+      const remoteAgents = await Agent.listRemote(conn);
+      const demoAgent = remoteAgents.find(bot => bot.DeveloperName === demoAgentName);
+
+      if (!demoAgent) {
+        vscode.window.showErrorMessage(`Could not find agent with developer name '${demoAgentName}' in the org.`);
+        return;
+      }
+
+      // for when the APIs are real
+      // Read and compile the .afscript file
+      // 
+      // const fileContents = Buffer.from((await vscode.workspace.fs.readFile(vscode.Uri.file(filePath)))).toString();
+      // try {
+      //   await Agent.compileAfScript(conn, fileContents);
+      // } catch (compileError) {
+      //   const error = SfError.wrap(compileError);
+      //   channelService.showChannelOutput();
+      //   channelService.clear();
+      //   channelService.appendLine('❌ AF Script validation failed! Cannot preview invalid script.');
+      //   channelService.appendLine('────────────────────────────────────────────────────────────────────────');
+      //   channelService.appendLine(`Error: ${error.message}`);
+      //   return;
+      // }
+
+      // Open the Agent Preview panel and select the demo agent
+      const provider = AgentCombinedViewProvider.getInstance();
+      if (!provider) {
+        vscode.window.showErrorMessage('Failed to get Agent Preview provider.');
+        return;
+      }
+
+      // Set the preselected agent ID and open the view
+      provider.setPreselectedAgentId(demoAgent.Id);
+      await vscode.commands.executeCommand('workbench.view.extension.agentforce-dx');
+      vscode.commands.executeCommand('setContext', 'sf:project_opened', true);
+      provider.webviewView?.webview.postMessage({
+        command: 'startSession',
+        data: { agentId: demoAgent.Id }
+      });
+
+    } catch (e) {
+      const error = SfError.wrap(e);
+      channelService.appendLine('❌ Error previewing .afscript file!');
+      channelService.appendLine('');
+      channelService.appendLine('Error Details:');
+      channelService.appendLine('────────────────────────────────────────────────────────────────────────');
+      channelService.appendLine(`Error: ${error.message}`);
+      
+      if (error.stack) {
+        channelService.appendLine('');
+        channelService.appendLine('Stack Trace:');
+        channelService.appendLine('────────────────────────────────────────────────────────────────────────');
+        channelService.appendLine(error.stack);
+      }
+    }
+  });
+};

--- a/src/enums/commands.ts
+++ b/src/enums/commands.ts
@@ -3,6 +3,7 @@ export enum Commands {
   activateAgent = 'salesforcedx-vscode-agents.activateAgent',
   deactivateAgent = 'salesforcedx-vscode-agents.deactivateAgent',
   validateAfScript = 'salesforcedx-vscode-agents.validateAfScript',
+  previewAfScript = 'salesforcedx-vscode-agents.previewAfScript',
   goToTestResults = 'sf.agent.test.view.goToTestResults',
   runTest = 'sf.agent.test.view.runTest',
   refreshTestView = 'sf.agent.test.view.refresh',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,7 @@ export async function activate(context: vscode.ExtensionContext) {
     disposables.push(commands.registerActivateAgentCommand());
     disposables.push(commands.registerDeactivateAgentCommand());
     disposables.push(commands.registerValidateAfScriptCommand());
+    disposables.push(commands.registerPreviewAfScriptCommand());
     context.subscriptions.push(await registerTestView());
     context.subscriptions.push(registerAgentCombinedView(context));
 


### PR DESCRIPTION
### What does this PR do?
adds `preview AfScript` context menu option to `.afscript`files

### What issues does this PR fix or reference?

@W-19775417@

### Functionality Before
N/A

### Functionality After
<img width="496" height="83" alt="image" src="https://github.com/user-attachments/assets/17579a9d-88ea-41dc-a8e0-967dc4080c9b" />

should launch straight to the agent preview, with the `SF_DEMO_AGENT` chosen and conversation started

### Testing Setup Notes

more env var fun with the debugger vsc instance, I updated this line like 
```typescript
      const demoAgentName = process.env.SF_DEMO_AGENT ?? 'Guest_Experience_Agent';
```
during testing/development