### PR TITLE
Wr/open aab @W-21858127@ 

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,6 +290,11 @@
           "command": "salesforcedx-vscode-agents.openAgentInOrg",
           "when": "resourceFilename =~ /.*\\.bot-meta\\.xml$/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ ||  resourceFilename =~ /.*\\.botVersion-meta\\.xml$/ || resourceFilename =~ /.*Planner\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml$/ || resourcePath =~ /genAiPlannerBundles/",
           "group": "agent@2"
+        },
+        {
+          "command": "salesforcedx-vscode-agents.openAuthoringBundleInOrg",
+          "when": "resourcePath =~ /aiAuthoringBundles/",
+          "group": "agent@2"
         }
       ],
       "explorer/context": [
@@ -326,6 +331,11 @@
         {
           "command": "salesforcedx-vscode-agents.openAgentInOrg",
           "when": "resourceFilename =~ /.*\\.bot-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlannerBundle/ || resourceFilename =~ /.*\\.botVersion-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml/ || resourcePath =~ /genAiPlannerBundles/",
+          "group": "agent@2"
+        },
+        {
+          "command": "salesforcedx-vscode-agents.openAuthoringBundleInOrg",
+          "when": "resourcePath =~ /aiAuthoringBundles/",
           "group": "agent@2"
         }
       ],
@@ -518,6 +528,10 @@
       },
       {
         "command": "salesforcedx-vscode-agents.openAgentInOrg",
+        "title": "%salesforcedx-vscode-agents.openAgentInOrg%"
+      },
+      {
+        "command": "salesforcedx-vscode-agents.openAuthoringBundleInOrg",
         "title": "%salesforcedx-vscode-agents.openAgentInOrg%"
       },
       {

--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
         },
         {
           "command": "salesforcedx-vscode-agents.openAgentInOrg",
-          "when": "resourceFilename =~ /.*\\.bot-meta\\.xml$/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ ||  resourceFilename =~ /.*\\.botVersion-meta\\.xml$/ || resourceFilename =~ /.*Planner\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml$/",
+          "when": "resourceFilename =~ /.*\\.bot-meta\\.xml$/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ ||  resourceFilename =~ /.*\\.botVersion-meta\\.xml$/ || resourceFilename =~ /.*Planner\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml$/ || resourcePath =~ /genAiPlannerBundles/",
           "group": "agent@2"
         }
       ],
@@ -325,7 +325,7 @@
         },
         {
           "command": "salesforcedx-vscode-agents.openAgentInOrg",
-          "when": "resourceFilename =~ /.*\\.bot-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlannerBundle/ || resourceFilename =~ /.*\\.botVersion-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml/",
+          "when": "resourceFilename =~ /.*\\.bot-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlannerBundle$/ || resourceFilename =~ /.*\\.genAiPlannerBundle/ || resourceFilename =~ /.*\\.botVersion-meta\\.xml/ || resourceFilename =~ /.*\\.genAiPlanner-meta\\.xml/ || resourcePath =~ /genAiPlannerBundles/",
           "group": "agent@2"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -532,7 +532,7 @@
       },
       {
         "command": "salesforcedx-vscode-agents.openAuthoringBundleInOrg",
-        "title": "%salesforcedx-vscode-agents.openAgentInOrg%"
+        "title": "%salesforcedx-vscode-agents.openAuthoringBundleInOrg%"
       },
       {
         "command": "salesforcedx-vscode-agents.activateAgent",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,6 @@
 {
   "salesforcedx-vscode-agents.openAgentInOrg": "AFDX: Open Agent in Default Org",
+  "salesforcedx-vscode-agents.openAuthoringBundleInOrg": "AFDX: Open Authoring Bundle in Default Org",
   "salesforcedx-vscode-agents.activateAgent": "AFDX: Activate Agent",
   "salesforcedx-vscode-agents.deactivateAgent": "AFDX: Deactivate Agent",
   "agent_test_view_name": "Agent Tests",

--- a/src/commands/agentUtils.ts
+++ b/src/commands/agentUtils.ts
@@ -16,7 +16,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { SfProject, ConfigAggregator, Org } from '@salesforce/core';
+import { ConfigAggregator, Org, SfProject } from '@salesforce/core';
 import { Agent } from '@salesforce/agents';
 
 const UNSUPPORTED_AGENTS = ['Copilot_for_Salesforce'];
@@ -35,9 +35,7 @@ export async function getConnectionAndProject() {
   return { conn: org.getConnection(), project: SfProject.getInstance() };
 }
 
-export async function getPublishedAgents(
-  conn: ReturnType<Org['getConnection']>
-): Promise<PublishedAgentInfo[]> {
+export async function getPublishedAgents(conn: ReturnType<Org['getConnection']>): Promise<PublishedAgentInfo[]> {
   const agents = await Agent.listRemote(conn);
   return agents
     .filter(a => !a.IsDeleted && !UNSUPPORTED_AGENTS.includes(a.DeveloperName))
@@ -57,6 +55,12 @@ export async function getAgentNameFromPath(targetPath: string): Promise<string> 
   const plannerBundleAgentName = getAgentNameFromPlannerBundlePath(targetPath);
   if (plannerBundleAgentName) {
     return plannerBundleAgentName;
+  }
+
+  // Then check if this is in an aiAuthoringBundles directory
+  const authoringBundleAgentName = getAgentNameFromAuthoringBundlePath(targetPath);
+  if (authoringBundleAgentName) {
+    return authoringBundleAgentName;
   }
 
   const stat = await vscode.workspace.fs.stat(vscode.Uri.file(targetPath));
@@ -104,6 +108,31 @@ function getAgentNameFromPlannerBundlePath(targetPath: string): string | null {
   agentIdentifier = agentIdentifier.replace(/_v\d+$/, '');
 
   return agentIdentifier;
+}
+
+/**
+ * Extracts the agent name from a path within the aiAuthoringBundles directory.
+ * Handles files/directories at any depth within aiAuthoringBundles.
+ *
+ * @param targetPath - The path to check
+ * @returns The agent name if the path is within aiAuthoringBundles, or null otherwise
+ *
+ * Examples:
+ * - force-app/main/default/aiAuthoringBundles/MyAgent/MyAgent.agent -> MyAgent
+ * - force-app/main/default/aiAuthoringBundles/MyAgent/ -> MyAgent
+ * - force-app/main/default/aiAuthoringBundles/MyAgent/instructions.txt -> MyAgent
+ */
+function getAgentNameFromAuthoringBundlePath(targetPath: string): string | null {
+  const pathParts = targetPath.split(path.sep);
+  const authoringBundlesIndex = pathParts.findIndex(part => part === 'aiAuthoringBundles');
+
+  if (authoringBundlesIndex === -1 || authoringBundlesIndex >= pathParts.length - 1) {
+    // Not in aiAuthoringBundles directory, or aiAuthoringBundles is the last part
+    return null;
+  }
+
+  // The agent name is the first item after aiAuthoringBundles (the directory name)
+  return pathParts[authoringBundlesIndex + 1];
 }
 
 /**

--- a/src/commands/agentUtils.ts
+++ b/src/commands/agentUtils.ts
@@ -16,7 +16,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { ConfigAggregator, Org, SfProject } from '@salesforce/core';
+import { ConfigAggregator, Org, SfError, SfProject } from '@salesforce/core';
 import { Agent } from '@salesforce/agents';
 
 const UNSUPPORTED_AGENTS = ['Copilot_for_Salesforce'];
@@ -28,7 +28,7 @@ export interface PublishedAgentInfo {
 }
 
 export interface Logger {
-  error(message: string): void;
+  error(message: string, error?: SfError): void;
   debug(message: string): void;
 }
 
@@ -88,9 +88,10 @@ export function handleCommandError(
   logger: Logger,
   telemetryService?: TelemetryService
 ): void {
-  const errorMessage = error instanceof Error ? error.message : String(error);
+  const sfError = SfError.wrap(error);
+  const errorMessage = sfError.message;
   vscode.window.showErrorMessage(`${userMessage}: ${errorMessage}`);
-  logger.error(`${userMessage}: ${errorMessage}`);
+  logger.error(`${userMessage}: ${errorMessage}`, sfError);
   telemetryService?.sendException(exceptionName, errorMessage);
 }
 
@@ -134,70 +135,78 @@ export async function getAgentNameFromPath(targetPath: string): Promise<string> 
   }
 }
 
-// Returns agent name from genAiPlannerBundles path (removes .genAiPlannerBundle extension and version suffix)
-function getAgentNameFromPlannerBundlePath(targetPath: string): string | null {
+// Extracts agent name from bundle paths (genAiPlannerBundles or aiAuthoringBundles)
+function getAgentNameFromBundlePath(
+  targetPath: string,
+  bundleDir: string,
+  stripExtension?: string,
+  stripVersionSuffix = false
+): string | null {
   // Normalize to handle cross-platform path separators (/ on Unix, \ on Windows)
   const normalizedPath = path.normalize(targetPath);
   const pathParts = normalizedPath.split(path.sep);
-  const plannerBundlesIndex = pathParts.findIndex(part => part === 'genAiPlannerBundles');
+  const bundleIndex = pathParts.findIndex(part => part === bundleDir);
 
-  if (plannerBundlesIndex === -1 || plannerBundlesIndex >= pathParts.length - 1) {
-    // Not in genAiPlannerBundles directory, or genAiPlannerBundles is the last part
+  if (bundleIndex === -1 || bundleIndex >= pathParts.length - 1) {
     return null;
   }
 
-  // The agent name is the first item after genAiPlannerBundles
-  let agentIdentifier = pathParts[plannerBundlesIndex + 1];
+  // The agent name is the first item after the bundle directory
+  let agentIdentifier = pathParts[bundleIndex + 1];
 
-  // If it's a .genAiPlannerBundle file, remove the extension
-  if (agentIdentifier.endsWith('.genAiPlannerBundle')) {
-    agentIdentifier = agentIdentifier.replace('.genAiPlannerBundle', '');
+  // Remove extension if specified
+  if (stripExtension && agentIdentifier.endsWith(stripExtension)) {
+    agentIdentifier = agentIdentifier.replace(stripExtension, '');
   }
 
-  // Always remove version suffix (e.g., _v1, _v2, _v33, etc.) from directory or file names
-  agentIdentifier = agentIdentifier.replace(/_v\d+$/, '');
+  // Remove version suffix if requested
+  if (stripVersionSuffix) {
+    agentIdentifier = agentIdentifier.replace(/_v\d+$/, '');
+  }
 
   return agentIdentifier;
 }
 
-// Returns agent name from aiAuthoringBundles path (directory name after aiAuthoringBundles)
-function getAgentNameFromAuthoringBundlePath(targetPath: string): string | null {
-  // Normalize to handle cross-platform path separators (/ on Unix, \ on Windows)
-  const normalizedPath = path.normalize(targetPath);
-  const pathParts = normalizedPath.split(path.sep);
-  const authoringBundlesIndex = pathParts.findIndex(part => part === 'aiAuthoringBundles');
+// Returns agent name from genAiPlannerBundles path
+function getAgentNameFromPlannerBundlePath(targetPath: string): string | null {
+  return getAgentNameFromBundlePath(targetPath, 'genAiPlannerBundles', '.genAiPlannerBundle', true);
+}
 
-  if (authoringBundlesIndex === -1 || authoringBundlesIndex >= pathParts.length - 1) {
-    // Not in aiAuthoringBundles directory, or aiAuthoringBundles is the last part
+// Returns agent name from aiAuthoringBundles path
+function getAgentNameFromAuthoringBundlePath(targetPath: string): string | null {
+  return getAgentNameFromBundlePath(targetPath, 'aiAuthoringBundles');
+}
+
+/**
+ * Helper to find .bot-meta.xml file in a directory and extract agent name.
+ * Returns null if not found.
+ */
+async function findBotMetaXmlInDirectory(directoryPath: string): Promise<string | null> {
+  try {
+    const dirUri = vscode.Uri.file(directoryPath);
+    const files = await vscode.workspace.fs.readDirectory(dirUri);
+    const botMetaFile = files.find(([name, type]) => type === vscode.FileType.File && name.endsWith('.bot-meta.xml'));
+
+    if (botMetaFile) {
+      return botMetaFile[0].replace('.bot-meta.xml', '');
+    }
+    return null;
+  } catch (error) {
     return null;
   }
-
-  // The agent name is the first item after aiAuthoringBundles (the directory name)
-  return pathParts[authoringBundlesIndex + 1];
 }
 
 /**
  * Extracts the agent name from a directory by looking for a .bot-meta.xml file.
  */
 async function getAgentNameFromDirectory(directoryPath: string): Promise<string> {
-  try {
-    const dirUri = vscode.Uri.file(directoryPath);
-    const files = await vscode.workspace.fs.readDirectory(dirUri);
-
-    // Find the .bot-meta.xml file
-    const botMetaFile = files.find(([name, type]) => type === vscode.FileType.File && name.endsWith('.bot-meta.xml'));
-
-    if (botMetaFile) {
-      // Extract bot name from the .bot-meta.xml filename
-      return botMetaFile[0].replace('.bot-meta.xml', '');
-    }
-
-    // Fallback: use the directory name (assuming it's the bot name)
-    return path.basename(directoryPath);
-  } catch (error) {
-    console.warn('Failed to read directory for bot metadata, falling back to directory name:', error);
-    return path.basename(directoryPath);
+  const agentName = await findBotMetaXmlInDirectory(directoryPath);
+  if (agentName) {
+    return agentName;
   }
+
+  // Fallback: use the directory name
+  return path.basename(directoryPath);
 }
 
 /**
@@ -226,17 +235,10 @@ export async function getAgentNameFromFile(fileName: string, filePath: string): 
   if (fileName.endsWith('.botVersion-meta.xml')) {
     try {
       const directory = path.dirname(filePath);
-      const dirUri = vscode.Uri.file(directory);
+      const agentName = await findBotMetaXmlInDirectory(directory);
 
-      // Read all files in the directory
-      const files = await vscode.workspace.fs.readDirectory(dirUri);
-
-      // Find the .bot-meta.xml file
-      const botMetaFile = files.find(([name, type]) => type === vscode.FileType.File && name.endsWith('.bot-meta.xml'));
-
-      if (botMetaFile) {
-        // Extract bot name from the .bot-meta.xml filename
-        return botMetaFile[0].replace('.bot-meta.xml', '');
+      if (agentName) {
+        return agentName;
       }
 
       // Fallback: try to infer from the file path structure

--- a/src/commands/agentUtils.ts
+++ b/src/commands/agentUtils.ts
@@ -27,12 +27,71 @@ export interface PublishedAgentInfo {
   isActivated: boolean;
 }
 
+export interface Logger {
+  error(message: string): void;
+  debug(message: string): void;
+}
+
+export interface TelemetryService {
+  sendException(exceptionName: string, message: string): void;
+}
+
 export async function getConnectionAndProject() {
   const configAggregator = await ConfigAggregator.create();
-  const org = await Org.create({
-    aliasOrUsername: configAggregator.getPropertyValue<string>('target-org') ?? 'undefined'
-  });
-  return { conn: org.getConnection(), project: SfProject.getInstance() };
+  const targetOrg = configAggregator.getPropertyValue<string>('target-org');
+
+  if (!targetOrg) {
+    throw new Error('No default org configured. Set a target org with "sf config set target-org".');
+  }
+
+  const org = await Org.create({ aliasOrUsername: targetOrg });
+  return { conn: org.getConnection(), project: SfProject.getInstance(), org };
+}
+
+/**
+ * Prompts user to select an agent from the current DX project.
+ * Returns undefined if no agent is selected or no agents are available.
+ */
+export async function selectAgentFromProject(
+  logger: Logger,
+  telemetryService?: TelemetryService
+): Promise<string | undefined> {
+  const project = SfProject.getInstance();
+  const agents = await Agent.list(project);
+
+  if (agents.length === 0) {
+    vscode.window.showErrorMessage(`Couldn't find any agents in the current DX project.`);
+    logger.error("Couldn't find any agents in the current DX project.");
+    logger.debug(
+      'Suggestion: Retrieve your agent metadata to your DX project with the "project retrieve start" CLI command.'
+    );
+    return undefined;
+  }
+
+  const agentName = await vscode.window.showQuickPick(agents, { placeHolder: 'Agent name (type to search)' });
+
+  if (!agentName) {
+    telemetryService?.sendException('no_agent_selected', 'No Agent selected');
+    return undefined;
+  }
+
+  return agentName;
+}
+
+/**
+ * Handles command errors with consistent messaging and telemetry.
+ */
+export function handleCommandError(
+  error: unknown,
+  userMessage: string,
+  exceptionName: string,
+  logger: Logger,
+  telemetryService?: TelemetryService
+): void {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  vscode.window.showErrorMessage(`${userMessage}: ${errorMessage}`);
+  logger.error(`${userMessage}: ${errorMessage}`);
+  telemetryService?.sendException(exceptionName, errorMessage);
 }
 
 export async function getPublishedAgents(conn: ReturnType<Org['getConnection']>): Promise<PublishedAgentInfo[]> {
@@ -75,18 +134,7 @@ export async function getAgentNameFromPath(targetPath: string): Promise<string> 
   }
 }
 
-/**
- * Extracts the agent name from a path within the genAiPlannerBundles directory.
- * Handles files/directories at any depth within genAiPlannerBundles.
- *
- * @param targetPath - The path to check
- * @returns The agent name if the path is within genAiPlannerBundles, or null otherwise
- *
- * Examples:
- * - force-app/main/default/genAiPlannerBundles/MyAgent.genAiPlannerBundle -> MyAgent
- * - force-app/main/default/genAiPlannerBundles/MyAgent/file.txt -> MyAgent
- * - force-app/main/default/genAiPlannerBundles/MyAgent/subdir/file.txt -> MyAgent
- */
+// Returns agent name from genAiPlannerBundles path (removes .genAiPlannerBundle extension and version suffix)
 function getAgentNameFromPlannerBundlePath(targetPath: string): string | null {
   const pathParts = targetPath.split(path.sep);
   const plannerBundlesIndex = pathParts.findIndex(part => part === 'genAiPlannerBundles');
@@ -110,18 +158,7 @@ function getAgentNameFromPlannerBundlePath(targetPath: string): string | null {
   return agentIdentifier;
 }
 
-/**
- * Extracts the agent name from a path within the aiAuthoringBundles directory.
- * Handles files/directories at any depth within aiAuthoringBundles.
- *
- * @param targetPath - The path to check
- * @returns The agent name if the path is within aiAuthoringBundles, or null otherwise
- *
- * Examples:
- * - force-app/main/default/aiAuthoringBundles/MyAgent/MyAgent.agent -> MyAgent
- * - force-app/main/default/aiAuthoringBundles/MyAgent/ -> MyAgent
- * - force-app/main/default/aiAuthoringBundles/MyAgent/instructions.txt -> MyAgent
- */
+// Returns agent name from aiAuthoringBundles path (directory name after aiAuthoringBundles)
 function getAgentNameFromAuthoringBundlePath(targetPath: string): string | null {
   const pathParts = targetPath.split(path.sep);
   const authoringBundlesIndex = pathParts.findIndex(part => part === 'aiAuthoringBundles');

--- a/src/commands/agentUtils.ts
+++ b/src/commands/agentUtils.ts
@@ -136,7 +136,9 @@ export async function getAgentNameFromPath(targetPath: string): Promise<string> 
 
 // Returns agent name from genAiPlannerBundles path (removes .genAiPlannerBundle extension and version suffix)
 function getAgentNameFromPlannerBundlePath(targetPath: string): string | null {
-  const pathParts = targetPath.split(path.sep);
+  // Normalize to handle cross-platform path separators (/ on Unix, \ on Windows)
+  const normalizedPath = path.normalize(targetPath);
+  const pathParts = normalizedPath.split(path.sep);
   const plannerBundlesIndex = pathParts.findIndex(part => part === 'genAiPlannerBundles');
 
   if (plannerBundlesIndex === -1 || plannerBundlesIndex >= pathParts.length - 1) {
@@ -160,7 +162,9 @@ function getAgentNameFromPlannerBundlePath(targetPath: string): string | null {
 
 // Returns agent name from aiAuthoringBundles path (directory name after aiAuthoringBundles)
 function getAgentNameFromAuthoringBundlePath(targetPath: string): string | null {
-  const pathParts = targetPath.split(path.sep);
+  // Normalize to handle cross-platform path separators (/ on Unix, \ on Windows)
+  const normalizedPath = path.normalize(targetPath);
+  const pathParts = normalizedPath.split(path.sep);
   const authoringBundlesIndex = pathParts.findIndex(part => part === 'aiAuthoringBundles');
 
   if (authoringBundlesIndex === -1 || authoringBundlesIndex >= pathParts.length - 1) {

--- a/src/commands/agentUtils.ts
+++ b/src/commands/agentUtils.ts
@@ -53,6 +53,12 @@ export async function getPublishedAgents(
  * Handles both file selections and directory selections.
  */
 export async function getAgentNameFromPath(targetPath: string): Promise<string> {
+  // First check if this is in a genAiPlannerBundles directory
+  const plannerBundleAgentName = getAgentNameFromPlannerBundlePath(targetPath);
+  if (plannerBundleAgentName) {
+    return plannerBundleAgentName;
+  }
+
   const stat = await vscode.workspace.fs.stat(vscode.Uri.file(targetPath));
 
   if (stat.type === vscode.FileType.Directory) {
@@ -63,6 +69,41 @@ export async function getAgentNameFromPath(targetPath: string): Promise<string> 
     const fileName = path.basename(targetPath);
     return getAgentNameFromFile(fileName, targetPath);
   }
+}
+
+/**
+ * Extracts the agent name from a path within the genAiPlannerBundles directory.
+ * Handles files/directories at any depth within genAiPlannerBundles.
+ *
+ * @param targetPath - The path to check
+ * @returns The agent name if the path is within genAiPlannerBundles, or null otherwise
+ *
+ * Examples:
+ * - force-app/main/default/genAiPlannerBundles/MyAgent.genAiPlannerBundle -> MyAgent
+ * - force-app/main/default/genAiPlannerBundles/MyAgent/file.txt -> MyAgent
+ * - force-app/main/default/genAiPlannerBundles/MyAgent/subdir/file.txt -> MyAgent
+ */
+function getAgentNameFromPlannerBundlePath(targetPath: string): string | null {
+  const pathParts = targetPath.split(path.sep);
+  const plannerBundlesIndex = pathParts.findIndex(part => part === 'genAiPlannerBundles');
+
+  if (plannerBundlesIndex === -1 || plannerBundlesIndex >= pathParts.length - 1) {
+    // Not in genAiPlannerBundles directory, or genAiPlannerBundles is the last part
+    return null;
+  }
+
+  // The agent name is the first item after genAiPlannerBundles
+  let agentIdentifier = pathParts[plannerBundlesIndex + 1];
+
+  // If it's a .genAiPlannerBundle file, remove the extension
+  if (agentIdentifier.endsWith('.genAiPlannerBundle')) {
+    agentIdentifier = agentIdentifier.replace('.genAiPlannerBundle', '');
+  }
+
+  // Always remove version suffix (e.g., _v1, _v2, _v33, etc.) from directory or file names
+  agentIdentifier = agentIdentifier.replace(/_v\d+$/, '');
+
+  return agentIdentifier;
 }
 
 /**

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,5 @@
 export * from './openAgentInOrg';
+export * from './openAuthoringBundleInOrg';
 export * from './activateAgent';
 export * from './deactivateAgent';
 export * from './validateAgent';

--- a/src/commands/openAgentInOrg.ts
+++ b/src/commands/openAgentInOrg.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import { Commands } from '../enums/commands';
-import { SfProject, SfError } from '@salesforce/core';
+import { SfProject, ConfigAggregator, Org } from '@salesforce/core';
 import { Agent } from '@salesforce/agents';
-import { sync } from 'cross-spawn';
 import { CoreExtensionService } from '../services/coreExtensionService';
 import { getAgentNameFromPath } from './agentUtils';
 import { Logger } from '../utils/logger';
@@ -54,12 +53,48 @@ export const registerOpenAgentInOrgCommand = () => {
       },
       async progress => {
         progress.report({ message: 'Opening agent in the default org...' });
-        const result = sync('sf', ['org', 'open', 'agent', '--api-name', agentName]);
-        if (result.status !== 0) {
-          vscode.window.showErrorMessage(`Unable to open agent: ${result.stderr.toString()}`);
-          telemetryService?.sendException('sf_command_failed', `stderr: ${result.stderr.toString()}`);
-        } else {
-          vscode.window.showInformationMessage('Agent was opened successfully in the default org.');
+
+        try {
+          // Get org connection
+          const configAggregator = await ConfigAggregator.create();
+          const org = await Org.create({
+            aliasOrUsername: configAggregator.getPropertyValue<string>('target-org') ?? 'undefined'
+          });
+          const conn = org.getConnection();
+
+          // Query BotDefinition to get the Bot ID (same as CLI does)
+          const query = `SELECT Id FROM BotDefinition WHERE DeveloperName='${agentName}'`;
+          const result = await conn.singleRecordQuery<{ Id: string }>(query, { tooling: false });
+
+          if (!result?.Id) {
+            vscode.window.showErrorMessage(`Agent "${agentName}" not found in org.`);
+            logger.error(`Agent "${agentName}" not found in org.`);
+            logger.debug(
+              'Suggestion: Ensure the agent is deployed to your org with the "project deploy start" CLI command.'
+            );
+            telemetryService?.sendException('agent_not_found', `Agent "${agentName}" not found in org`);
+            return;
+          }
+
+          const botId = result.Id;
+
+          // Construct the Agent Builder redirect URL (same as CLI)
+          const redirectUri = `AiCopilot/copilotStudio.app#/copilot/builder?copilotId=${botId}`;
+
+          // Generate frontdoor URL with authentication
+          const frontdoorUrl = await org.getFrontDoorUrl(redirectUri);
+
+          // Open in browser using VS Code
+          // Cast to any to prevent VS Code from parsing/encoding the URL
+          // This preserves the already-encoded URL exactly as-is
+          await vscode.env.openExternal(frontdoorUrl as any); // doesn't change string
+
+          vscode.window.showInformationMessage('Agent opened successfully in the default org.');
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          vscode.window.showErrorMessage(`Unable to open agent: ${errorMessage}`);
+          logger.error(`Unable to open agent: ${errorMessage}`);
+          telemetryService?.sendException('open_agent_failed', errorMessage);
         }
       }
     );

--- a/src/commands/openAgentInOrg.ts
+++ b/src/commands/openAgentInOrg.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
 import { Commands } from '../enums/commands';
-import { SfProject, ConfigAggregator, Org } from '@salesforce/core';
-import { Agent } from '@salesforce/agents';
 import { CoreExtensionService } from '../services/coreExtensionService';
-import { getAgentNameFromPath } from './agentUtils';
+import { getAgentNameFromPath, selectAgentFromProject, getConnectionAndProject, handleCommandError } from './agentUtils';
 import { Logger } from '../utils/logger';
 
 export const registerOpenAgentInOrgCommand = () => {
@@ -27,21 +25,8 @@ export const registerOpenAgentInOrgCommand = () => {
 
     // If no agent name from context, prompt user to select
     if (!agentName) {
-      const project = SfProject.getInstance();
-      const agents = await Agent.list(project);
-      if (agents.length === 0) {
-        vscode.window.showErrorMessage(`Couldn't find any agents in the current DX project.`);
-        logger.error("Couldn't find any agents in the current DX project.");
-        logger.debug(
-          'Suggestion: Retrieve your agent metadata to your DX project with the "project retrieve start" CLI command.'
-        );
-        return;
-      }
-      // we need to prompt the user which agent to open
-      agentName = await vscode.window.showQuickPick(agents, { placeHolder: 'Agent name (type to search)' });
-
+      agentName = await selectAgentFromProject(logger, telemetryService);
       if (!agentName) {
-        telemetryService?.sendException('no_agent_selected', 'No Agent selected');
         return;
       }
     }
@@ -57,18 +42,7 @@ export const registerOpenAgentInOrgCommand = () => {
 
         try {
           // Get org connection
-          const configAggregator = await ConfigAggregator.create();
-          const targetOrg = configAggregator.getPropertyValue<string>('target-org');
-
-          if (!targetOrg) {
-            vscode.window.showErrorMessage('No default org configured. Set a target org with "sf config set target-org".');
-            logger.error('No default org configured.');
-            telemetryService?.sendException('no_target_org', 'No default org configured');
-            return;
-          }
-
-          const org = await Org.create({ aliasOrUsername: targetOrg });
-          const conn = org.getConnection();
+          const { conn, org } = await getConnectionAndProject();
 
           // Query BotDefinition to get the Bot ID (same as CLI does)
           // Escape single quotes in agent name to prevent SQL injection
@@ -101,10 +75,7 @@ export const registerOpenAgentInOrgCommand = () => {
 
           vscode.window.showInformationMessage('Agent opened successfully in the default org.');
         } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          vscode.window.showErrorMessage(`Unable to open agent: ${errorMessage}`);
-          logger.error(`Unable to open agent: ${errorMessage}`);
-          telemetryService?.sendException('open_agent_failed', errorMessage);
+          handleCommandError(error, 'Unable to open agent', 'open_agent_failed', logger, telemetryService);
         }
       }
     );

--- a/src/commands/openAgentInOrg.ts
+++ b/src/commands/openAgentInOrg.ts
@@ -58,9 +58,16 @@ export const registerOpenAgentInOrgCommand = () => {
         try {
           // Get org connection
           const configAggregator = await ConfigAggregator.create();
-          const org = await Org.create({
-            aliasOrUsername: configAggregator.getPropertyValue<string>('target-org') ?? 'undefined'
-          });
+          const targetOrg = configAggregator.getPropertyValue<string>('target-org');
+
+          if (!targetOrg) {
+            vscode.window.showErrorMessage('No default org configured. Set a target org with "sf config set target-org".');
+            logger.error('No default org configured.');
+            telemetryService?.sendException('no_target_org', 'No default org configured');
+            return;
+          }
+
+          const org = await Org.create({ aliasOrUsername: targetOrg });
           const conn = org.getConnection();
 
           // Query BotDefinition to get the Bot ID (same as CLI does)

--- a/src/commands/openAgentInOrg.ts
+++ b/src/commands/openAgentInOrg.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Commands } from '../enums/commands';
+import { SfError } from '@salesforce/core';
 import { CoreExtensionService } from '../services/coreExtensionService';
 import { getAgentNameFromPath, selectAgentFromProject, getConnectionAndProject, handleCommandError } from './agentUtils';
 import { Logger } from '../utils/logger';

--- a/src/commands/openAgentInOrg.ts
+++ b/src/commands/openAgentInOrg.ts
@@ -64,7 +64,9 @@ export const registerOpenAgentInOrgCommand = () => {
           const conn = org.getConnection();
 
           // Query BotDefinition to get the Bot ID (same as CLI does)
-          const query = `SELECT Id FROM BotDefinition WHERE DeveloperName='${agentName}'`;
+          // Escape single quotes in agent name to prevent SQL injection
+          const escapedAgentName = agentName.replace(/'/g, "''");
+          const query = `SELECT Id FROM BotDefinition WHERE DeveloperName='${escapedAgentName}'`;
           const result = await conn.singleRecordQuery<{ Id: string }>(query, { tooling: false });
 
           if (!result?.Id) {

--- a/src/commands/openAuthoringBundleInOrg.ts
+++ b/src/commands/openAuthoringBundleInOrg.ts
@@ -58,9 +58,16 @@ export const registerOpenAuthoringBundleInOrgCommand = () => {
         try {
           // Get org connection
           const configAggregator = await ConfigAggregator.create();
-          const org = await Org.create({
-            aliasOrUsername: configAggregator.getPropertyValue<string>('target-org') ?? 'undefined'
-          });
+          const targetOrg = configAggregator.getPropertyValue<string>('target-org');
+
+          if (!targetOrg) {
+            vscode.window.showErrorMessage('No default org configured. Set a target org with "sf config set target-org".');
+            logger.error('No default org configured.');
+            telemetryService?.sendException('no_target_org', 'No default org configured');
+            return;
+          }
+
+          const org = await Org.create({ aliasOrUsername: targetOrg });
 
           // For aiAuthoringBundles (.agent files), use the agent authoring builder URL
           // URL format: AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=AgentName

--- a/src/commands/openAuthoringBundleInOrg.ts
+++ b/src/commands/openAuthoringBundleInOrg.ts
@@ -1,0 +1,87 @@
+import * as vscode from 'vscode';
+import { Commands } from '../enums/commands';
+import { SfProject, ConfigAggregator, Org } from '@salesforce/core';
+import { Agent } from '@salesforce/agents';
+import { CoreExtensionService } from '../services/coreExtensionService';
+import { getAgentNameFromPath } from './agentUtils';
+import { Logger } from '../utils/logger';
+
+export const registerOpenAuthoringBundleInOrgCommand = () => {
+  return vscode.commands.registerCommand(Commands.openAuthoringBundleInOrg, async (uri?: vscode.Uri) => {
+    const telemetryService = CoreExtensionService.getTelemetryService();
+    const logger = new Logger(CoreExtensionService.getChannelService());
+    const commandName = Commands.openAuthoringBundleInOrg;
+    const hrstart = process.hrtime();
+    telemetryService?.sendCommandEvent(commandName, hrstart, { commandName });
+
+    let agentName: string | undefined;
+
+    // If called from context menu with a file/directory, use that to determine the agent
+    if (uri?.fsPath) {
+      try {
+        agentName = await getAgentNameFromPath(uri.fsPath);
+      } catch (error) {
+        console.warn('Failed to get agent name from path, falling back to picker:', error);
+      }
+    }
+
+    // If no agent name from context, prompt user to select
+    if (!agentName) {
+      const project = SfProject.getInstance();
+      const agents = await Agent.list(project);
+      if (agents.length === 0) {
+        vscode.window.showErrorMessage(`Couldn't find any agents in the current DX project.`);
+        logger.error("Couldn't find any agents in the current DX project.");
+        logger.debug(
+          'Suggestion: Retrieve your agent metadata to your DX project with the "project retrieve start" CLI command.'
+        );
+        return;
+      }
+      // we need to prompt the user which agent to open
+      agentName = await vscode.window.showQuickPick(agents, { placeHolder: 'Agent name (type to search)' });
+
+      if (!agentName) {
+        telemetryService?.sendException('no_agent_selected', 'No Agent selected');
+        return;
+      }
+    }
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Open Agent in Org',
+        cancellable: true
+      },
+      async progress => {
+        progress.report({ message: `Opening ${agentName}` });
+
+        try {
+          // Get org connection
+          const configAggregator = await ConfigAggregator.create();
+          const org = await Org.create({
+            aliasOrUsername: configAggregator.getPropertyValue<string>('target-org') ?? 'undefined'
+          });
+
+          // For aiAuthoringBundles (.agent files), use the agent authoring builder URL
+          // URL format: AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=AgentName
+          const redirectUri = `AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=${agentName}`;
+
+          // Generate frontdoor URL with authentication
+          const frontdoorUrl = await org.getFrontDoorUrl(redirectUri);
+
+          // Open in browser using VS Code
+          // Cast to any to prevent VS Code from parsing/encoding the URL
+          // This preserves the already-encoded URL exactly as-is
+          await vscode.env.openExternal(frontdoorUrl as any); // doesn't change string
+
+          vscode.window.showInformationMessage('Agent opened successfully in the default org.');
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          vscode.window.showErrorMessage(`Unable to open agent: ${errorMessage}`);
+          logger.error(`Unable to open agent: ${errorMessage}`);
+          telemetryService?.sendException('open_agent_authoring_failed', errorMessage);
+        }
+      }
+    );
+  });
+};

--- a/src/commands/openAuthoringBundleInOrg.ts
+++ b/src/commands/openAuthoringBundleInOrg.ts
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2025, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as vscode from 'vscode';
 import { Commands } from '../enums/commands';
+import { SfError } from '@salesforce/core';
 import { CoreExtensionService } from '../services/coreExtensionService';
 import { getAgentNameFromPath, selectAgentFromProject, getConnectionAndProject, handleCommandError } from './agentUtils';
 import { Logger } from '../utils/logger';
@@ -46,7 +63,7 @@ export const registerOpenAuthoringBundleInOrgCommand = () => {
 
           // For aiAuthoringBundles (.agent files), use the agent authoring builder URL
           // URL format: AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=AgentName
-          const redirectUri = `AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=${agentName}`;
+          const redirectUri = `AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=${encodeURIComponent(agentName)}`;
 
           // Generate frontdoor URL with authentication
           const frontdoorUrl = await org.getFrontDoorUrl(redirectUri);

--- a/src/commands/openAuthoringBundleInOrg.ts
+++ b/src/commands/openAuthoringBundleInOrg.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
 import { Commands } from '../enums/commands';
-import { SfProject, ConfigAggregator, Org } from '@salesforce/core';
-import { Agent } from '@salesforce/agents';
 import { CoreExtensionService } from '../services/coreExtensionService';
-import { getAgentNameFromPath } from './agentUtils';
+import { getAgentNameFromPath, selectAgentFromProject, getConnectionAndProject, handleCommandError } from './agentUtils';
 import { Logger } from '../utils/logger';
 
 export const registerOpenAuthoringBundleInOrgCommand = () => {
@@ -27,21 +25,8 @@ export const registerOpenAuthoringBundleInOrgCommand = () => {
 
     // If no agent name from context, prompt user to select
     if (!agentName) {
-      const project = SfProject.getInstance();
-      const agents = await Agent.list(project);
-      if (agents.length === 0) {
-        vscode.window.showErrorMessage(`Couldn't find any agents in the current DX project.`);
-        logger.error("Couldn't find any agents in the current DX project.");
-        logger.debug(
-          'Suggestion: Retrieve your agent metadata to your DX project with the "project retrieve start" CLI command.'
-        );
-        return;
-      }
-      // we need to prompt the user which agent to open
-      agentName = await vscode.window.showQuickPick(agents, { placeHolder: 'Agent name (type to search)' });
-
+      agentName = await selectAgentFromProject(logger, telemetryService);
       if (!agentName) {
-        telemetryService?.sendException('no_agent_selected', 'No Agent selected');
         return;
       }
     }
@@ -57,17 +42,7 @@ export const registerOpenAuthoringBundleInOrgCommand = () => {
 
         try {
           // Get org connection
-          const configAggregator = await ConfigAggregator.create();
-          const targetOrg = configAggregator.getPropertyValue<string>('target-org');
-
-          if (!targetOrg) {
-            vscode.window.showErrorMessage('No default org configured. Set a target org with "sf config set target-org".');
-            logger.error('No default org configured.');
-            telemetryService?.sendException('no_target_org', 'No default org configured');
-            return;
-          }
-
-          const org = await Org.create({ aliasOrUsername: targetOrg });
+          const { org } = await getConnectionAndProject();
 
           // For aiAuthoringBundles (.agent files), use the agent authoring builder URL
           // URL format: AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=AgentName
@@ -83,10 +58,7 @@ export const registerOpenAuthoringBundleInOrgCommand = () => {
 
           vscode.window.showInformationMessage('Agent opened successfully in the default org.');
         } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          vscode.window.showErrorMessage(`Unable to open agent: ${errorMessage}`);
-          logger.error(`Unable to open agent: ${errorMessage}`);
-          telemetryService?.sendException('open_agent_authoring_failed', errorMessage);
+          handleCommandError(error, 'Unable to open agent', 'open_agent_authoring_failed', logger, telemetryService);
         }
       }
     );

--- a/src/enums/commands.ts
+++ b/src/enums/commands.ts
@@ -1,5 +1,6 @@
 export enum Commands {
   openAgentInOrg = 'salesforcedx-vscode-agents.openAgentInOrg',
+  openAuthoringBundleInOrg = 'salesforcedx-vscode-agents.openAuthoringBundleInOrg',
   activateAgent = 'salesforcedx-vscode-agents.activateAgent',
   deactivateAgent = 'salesforcedx-vscode-agents.deactivateAgent',
   validateAgent = 'salesforcedx-vscode-agents.validateAgent',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,8 +180,10 @@ const registerAgentCombinedView = (context: vscode.ExtensionContext): vscode.Dis
       console.error('Could not set up org change listener:', err.message);
     });
 
-  // Shared function for selecting and running an agent
-  const selectAndRunAgent = async () => {
+  // Shared helper for selecting an agent from a quick pick
+  const showAgentPicker = async (
+    placeHolder: string
+  ): Promise<{ id: string; source: AgentSource } | undefined> => {
     const channelService = CoreExtensionService.getChannelService();
 
     try {
@@ -228,41 +230,51 @@ const registerAgentCombinedView = (context: vscode.ExtensionContext): vscode.Dis
       if (allAgents.length === 0) {
         vscode.window.showErrorMessage('No agents found.');
         channelService.appendLine('No agents found.');
-        return;
+        return undefined;
       }
 
-      const selectedAgent = await vscode.window.showQuickPick(allAgents, {
-        placeHolder: 'Select an agent to run'
-      });
+      const selectedAgent = await vscode.window.showQuickPick(allAgents, { placeHolder });
 
-      if (selectedAgent && selectedAgent.id) {
-        // Store the preference so the dropdown adopts the selection if the webview refreshes
-        provider.setAgentId(selectedAgent.id);
-
-        // Reveal the Agentforce DX panel
-        await vscode.commands.executeCommand('sf.agent.combined.view.focus');
-
-        const postSelectionMessage = () => {
-          if (provider.webviewView?.webview) {
-            // Send the selectAgent message with agentSource to avoid expensive re-fetch
-            provider.webviewView.webview.postMessage({
-              command: 'selectAgent',
-              data: { agentId: selectedAgent.id, agentSource: selectedAgent.source }
-            });
-          }
-        };
-
-        // If the webview already exists, update it immediately; otherwise try shortly after focus
-        if (provider.webviewView?.webview) {
-          await postSelectionMessage();
-        } else {
-          setTimeout(() => postSelectionMessage(), 300);
-        }
+      if (selectedAgent?.id) {
+        return { id: selectedAgent.id, source: selectedAgent.source! };
       }
+
+      return undefined;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       vscode.window.showErrorMessage(`Failed to list agents: ${errorMessage}`);
       channelService.appendLine(`Failed to list agents: ${errorMessage}`);
+      return undefined;
+    }
+  };
+
+  // Command for selecting and running an agent
+  const selectAndRunAgent = async () => {
+    const selectedAgent = await showAgentPicker('Select an agent to run');
+
+    if (selectedAgent) {
+      // Store the preference so the dropdown adopts the selection if the webview refreshes
+      provider.setAgentId(selectedAgent.id);
+
+      // Reveal the Agentforce DX panel
+      await vscode.commands.executeCommand('sf.agent.combined.view.focus');
+
+      const postSelectionMessage = () => {
+        if (provider.webviewView?.webview) {
+          // Send the selectAgent message with agentSource to avoid expensive re-fetch
+          provider.webviewView.webview.postMessage({
+            command: 'selectAgent',
+            data: { agentId: selectedAgent.id, agentSource: selectedAgent.source }
+          });
+        }
+      };
+
+      // If the webview already exists, update it immediately; otherwise try shortly after focus
+      if (provider.webviewView?.webview) {
+        await postSelectionMessage();
+      } else {
+        setTimeout(() => postSelectionMessage(), 300);
+      }
     }
   };
 
@@ -279,69 +291,17 @@ const registerAgentCombinedView = (context: vscode.ExtensionContext): vscode.Dis
         provider.selectAndStartAgent(currentAgentId);
       } else {
         // If no agent selected, show picker and then start the selected agent
-        const channelService = CoreExtensionService.getChannelService();
+        const selectedAgent = await showAgentPicker('Select an agent to start');
 
-        try {
-          const availableAgents = await provider.getAgentsForCommandPalette();
-          const scriptAgents = availableAgents.filter(agent => agent.source === AgentSource.SCRIPT);
-          const publishedAgents = availableAgents.filter(agent => agent.source === AgentSource.PUBLISHED);
+        if (selectedAgent) {
+          // Store the preference so the dropdown adopts the selection if the webview refreshes
+          provider.setAgentId(selectedAgent.id);
 
-          const allAgents: Array<{
-            label: string;
-            description?: string;
-            id?: string;
-            source?: AgentSource;
-            kind?: vscode.QuickPickItemKind;
-          }> = [];
+          // Reveal the Agentforce DX panel
+          await vscode.commands.executeCommand('sf.agent.combined.view.focus');
 
-          if (scriptAgents.length > 0) {
-            allAgents.push({ label: 'Agent Script', kind: vscode.QuickPickItemKind.Separator });
-            allAgents.push(
-              ...scriptAgents.map(agent => ({
-                label: agent.name,
-                description: agent.id ? path.basename(agent.id) : undefined,
-                // For script agents, use aabName to match what the webview expects
-                id: agent.aabName || agent.id,
-                source: agent.source
-              }))
-            );
-          }
-
-          if (publishedAgents.length > 0) {
-            allAgents.push({ label: 'Published', kind: vscode.QuickPickItemKind.Separator });
-            allAgents.push(
-              ...publishedAgents.map(agent => ({
-                label: agent.name,
-                id: agent.id,
-                source: agent.source
-              }))
-            );
-          }
-
-          if (allAgents.length === 0) {
-            vscode.window.showErrorMessage('No agents found.');
-            channelService.appendLine('No agents found.');
-            return;
-          }
-
-          const selectedAgent = await vscode.window.showQuickPick(allAgents, {
-            placeHolder: 'Select an agent to start'
-          });
-
-          if (selectedAgent && selectedAgent.id) {
-            // Store the preference so the dropdown adopts the selection if the webview refreshes
-            provider.setAgentId(selectedAgent.id);
-
-            // Reveal the Agentforce DX panel
-            await vscode.commands.executeCommand('sf.agent.combined.view.focus');
-
-            // Start the selected agent
-            provider.selectAndStartAgent(selectedAgent.id);
-          }
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          vscode.window.showErrorMessage(`Failed to list agents: ${errorMessage}`);
-          channelService.appendLine(`Failed to list agents: ${errorMessage}`);
+          // Start the selected agent
+          provider.selectAndStartAgent(selectedAgent.id);
         }
       }
     })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,6 @@ import { AgentSource } from '@salesforce/agents';
 import { getTestOutlineProvider } from './views/testOutlineProvider';
 import { AgentTestRunner } from './views/testRunner';
 import { toggleGeneratedDataOn, toggleGeneratedDataOff } from './commands/toggleGeneratedData';
-import { initializeDiagnosticCollection } from './commands/validateAgent';
 
 // Export the provider instance for testing purposes
 let agentCombinedViewProviderInstance: AgentCombinedViewProvider | undefined;
@@ -43,12 +42,8 @@ export async function activate(context: vscode.ExtensionContext) {
       })
       .catch((err: Error) => console.error('Error loading core dependencies:', err));
 
-    // Note: CLI validation has been removed from activation to avoid false positives
-    // during startup. Commands will fail with appropriate error messages if the
-    // sf CLI or agent plugin is not installed.
-
     // Initialize diagnostic collection for agent validation
-    initializeDiagnosticCollection(context);
+    commands.initializeDiagnosticCollection(context);
 
     // Initialize and watch SF_SKIP_RETRIEVE setting
     const updateSkipRetrieveEnv = () => {
@@ -59,10 +54,10 @@ export async function activate(context: vscode.ExtensionContext) {
     // Set initial value
     updateSkipRetrieveEnv();
 
-
     // Register commands before initializing `testRunner`
     const disposables: vscode.Disposable[] = [];
     disposables.push(commands.registerOpenAgentInOrgCommand());
+    disposables.push(commands.registerOpenAuthoringBundleInOrgCommand());
     disposables.push(commands.registerActivateAgentCommand());
     disposables.push(commands.registerDeactivateAgentCommand());
     disposables.push(commands.registerValidateAgentCommand());
@@ -151,7 +146,6 @@ const registerTestView = async (): Promise<vscode.Disposable> => {
   return vscode.Disposable.from(...testViewItems);
 };
 
-
 const registerAgentCombinedView = (context: vscode.ExtensionContext): vscode.Disposable => {
   // Register webview to be disposed on extension deactivation
   const provider = new AgentCombinedViewProvider(context);
@@ -192,8 +186,12 @@ const registerAgentCombinedView = (context: vscode.ExtensionContext): vscode.Dis
 
     try {
       const availableAgents = await provider.getAgentsForCommandPalette();
-      const scriptAgents = availableAgents.filter(agent => agent.source === AgentSource.SCRIPT).sort((a, b) => (a.developerName ?? a.aabName ?? '').localeCompare(b.developerName ?? b.aabName ?? ''));
-      const publishedAgents = availableAgents.filter(agent => agent.source === AgentSource.PUBLISHED).sort((a, b) => (a.developerName ?? a.aabName ?? '').localeCompare(b.developerName ?? b.aabName ?? ''));
+      const scriptAgents = availableAgents
+        .filter(agent => agent.source === AgentSource.SCRIPT)
+        .sort((a, b) => (a.developerName ?? a.aabName ?? '').localeCompare(b.developerName ?? b.aabName ?? ''));
+      const publishedAgents = availableAgents
+        .filter(agent => agent.source === AgentSource.PUBLISHED)
+        .sort((a, b) => (a.developerName ?? a.aabName ?? '').localeCompare(b.developerName ?? b.aabName ?? ''));
 
       const allAgents: Array<{
         label: string;
@@ -372,7 +370,6 @@ const registerAgentCombinedView = (context: vscode.ExtensionContext): vscode.Dis
       }
     })
   );
-
 
   disposables.push(
     vscode.commands.registerCommand('sf.agent.combined.view.restart', async () => {

--- a/test/commands/botVersionParsing.test.ts
+++ b/test/commands/botVersionParsing.test.ts
@@ -276,4 +276,69 @@ describe('Directory Path Handling', () => {
 
     consoleWarnSpy.mockRestore();
   });
+
+  it('should extract agent name from genAiPlannerBundle file path', async () => {
+    const mockFilePath = '/Users/test/project/force-app/main/default/genAiPlannerBundles/MyAgent.genAiPlannerBundle';
+
+    const agentName = await getAgentNameFromPath(mockFilePath);
+    expect(agentName).toBe('MyAgent');
+  });
+
+  it('should extract agent name from genAiPlannerBundle file with version suffix', async () => {
+    const mockFilePath =
+      '/Users/test/project/force-app/main/default/genAiPlannerBundles/MyAgent_v2.genAiPlannerBundle';
+
+    const agentName = await getAgentNameFromPath(mockFilePath);
+    expect(agentName).toBe('MyAgent');
+  });
+
+  it('should extract agent name from directory under genAiPlannerBundles', async () => {
+    const mockDirPath = '/Users/test/project/force-app/main/default/genAiPlannerBundles/MyAgent';
+
+    const agentName = await getAgentNameFromPath(mockDirPath);
+    expect(agentName).toBe('MyAgent');
+  });
+
+  it('should extract agent name from versioned directory under genAiPlannerBundles', async () => {
+    const mockDirPath = '/Users/test/project/force-app/main/default/genAiPlannerBundles/Local_Info_Agent_v33';
+
+    const agentName = await getAgentNameFromPath(mockDirPath);
+    expect(agentName).toBe('Local_Info_Agent');
+  });
+
+  it('should extract agent name from file nested under genAiPlannerBundles agent directory', async () => {
+    const mockFilePath =
+      '/Users/test/project/force-app/main/default/genAiPlannerBundles/MyAgent/instructions/someFile.txt';
+
+    (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue({
+      type: vscode.FileType.File
+    });
+
+    const agentName = await getAgentNameFromPath(mockFilePath);
+    expect(agentName).toBe('MyAgent');
+  });
+
+  it('should extract agent name from deeply nested file under genAiPlannerBundles', async () => {
+    const mockFilePath =
+      '/Users/test/project/force-app/main/default/genAiPlannerBundles/MyAgent/subdir/nested/file.json';
+
+    (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue({
+      type: vscode.FileType.File
+    });
+
+    const agentName = await getAgentNameFromPath(mockFilePath);
+    expect(agentName).toBe('MyAgent');
+  });
+
+  it('should extract agent name from file in versioned directory under genAiPlannerBundles', async () => {
+    const mockFilePath =
+      '/Users/test/project/force-app/main/default/genAiPlannerBundles/Local_Info_Agent_v6/agentGraph/someFile.txt';
+
+    (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue({
+      type: vscode.FileType.File
+    });
+
+    const agentName = await getAgentNameFromPath(mockFilePath);
+    expect(agentName).toBe('Local_Info_Agent');
+  });
 });

--- a/test/commands/botVersionParsing.test.ts
+++ b/test/commands/botVersionParsing.test.ts
@@ -341,4 +341,35 @@ describe('Directory Path Handling', () => {
     const agentName = await getAgentNameFromPath(mockFilePath);
     expect(agentName).toBe('Local_Info_Agent');
   });
+
+  it('should extract agent name from .agent file in aiAuthoringBundles', async () => {
+    const mockFilePath =
+      '/Users/test/project/force-app/main/default/aiAuthoringBundles/MyAgent/MyAgent.agent';
+
+    (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue({
+      type: vscode.FileType.File
+    });
+
+    const agentName = await getAgentNameFromPath(mockFilePath);
+    expect(agentName).toBe('MyAgent');
+  });
+
+  it('should extract agent name from directory in aiAuthoringBundles', async () => {
+    const mockDirPath = '/Users/test/project/force-app/main/default/aiAuthoringBundles/MyAgent';
+
+    const agentName = await getAgentNameFromPath(mockDirPath);
+    expect(agentName).toBe('MyAgent');
+  });
+
+  it('should extract agent name from nested file in aiAuthoringBundles', async () => {
+    const mockFilePath =
+      '/Users/test/project/force-app/main/default/aiAuthoringBundles/MyAgent/instructions/file.txt';
+
+    (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue({
+      type: vscode.FileType.File
+    });
+
+    const agentName = await getAgentNameFromPath(mockFilePath);
+    expect(agentName).toBe('MyAgent');
+  });
 });

--- a/test/commands/openAgentInOrg.test.ts
+++ b/test/commands/openAgentInOrg.test.ts
@@ -1,15 +1,10 @@
 import * as vscode from 'vscode';
 import { registerOpenAgentInOrgCommand } from '../../src/commands/openAgentInOrg';
 import { Commands } from '../../src/enums/commands';
-import { SfProject } from '@salesforce/core';
-import { sync } from 'cross-spawn';
+import { SfProject, ConfigAggregator, Org } from '@salesforce/core';
 import { CoreExtensionService } from '../../src/services/coreExtensionService';
 import { Agent } from '@salesforce/agents';
 import * as agentUtils from '../../src/commands/agentUtils';
-
-jest.mock('cross-spawn', () => ({
-  sync: jest.fn()
-}));
 
 describe('registerOpenAgentInOrgCommand', () => {
   let commandSpy: jest.SpyInstance;
@@ -17,6 +12,10 @@ describe('registerOpenAgentInOrgCommand', () => {
   let quickPickSpy: jest.SpyInstance;
   let progressSpy: jest.SpyInstance;
   let errorMessageSpy: jest.SpyInstance;
+  let openExternalSpy: jest.SpyInstance;
+  let configAggregatorSpy: jest.SpyInstance;
+  let orgCreateSpy: jest.SpyInstance;
+
   const fakeTelemetryInstance: any = {
     sendException: jest.fn(),
     sendCommandEvent: jest.fn()
@@ -26,9 +25,29 @@ describe('registerOpenAgentInOrgCommand', () => {
     showChannelOutput: jest.fn(),
     clear: jest.fn()
   };
+  let mockConnection: any;
+  let mockConfigAggregator: any;
+  let mockOrg: any;
+
   beforeEach(() => {
+    // Reset mocks
+    mockConnection = {
+      instanceUrl: 'https://test.salesforce.com',
+      singleRecordQuery: jest.fn().mockResolvedValue({ Id: '0XxD60000004Cj2KAE' })
+    };
+    mockConfigAggregator = {
+      getPropertyValue: jest.fn().mockReturnValue('test-org')
+    };
+    mockOrg = {
+      getConnection: jest.fn().mockReturnValue(mockConnection),
+      getFrontDoorUrl: jest.fn().mockResolvedValue('https://test.salesforce.com/secur/frontdoor.jsp?otp=xxx&startURL=yyy')
+    };
+
     jest.spyOn(CoreExtensionService, 'getTelemetryService').mockReturnValue(fakeTelemetryInstance);
     jest.spyOn(CoreExtensionService, 'getChannelService').mockReturnValue(fakeChannelService);
+
+    configAggregatorSpy = jest.spyOn(ConfigAggregator, 'create').mockResolvedValue(mockConfigAggregator as any);
+    orgCreateSpy = jest.spyOn(Org, 'create').mockResolvedValue(mockOrg as any);
 
     jest.spyOn(Agent, 'list').mockResolvedValue(['Agent1', 'Agent2']);
 
@@ -36,12 +55,12 @@ describe('registerOpenAgentInOrgCommand', () => {
     projectSpy = jest.spyOn(SfProject, 'getInstance').mockReturnValue({
       getDefaultPackage: jest.fn().mockReturnValue({ fullPath: '/fake/path' })
     } as unknown as SfProject);
-    quickPickSpy = jest.spyOn(vscode.window, 'showQuickPick').mockResolvedValue([{ title: 'Agent1' }] as any);
+    quickPickSpy = jest.spyOn(vscode.window, 'showQuickPick').mockResolvedValue('Agent1' as any);
     errorMessageSpy = jest.spyOn(vscode.window, 'showErrorMessage').mockImplementation();
+    openExternalSpy = jest.spyOn(vscode.env, 'openExternal').mockResolvedValue(true);
     progressSpy = jest
       .spyOn(vscode.window, 'withProgress')
       .mockImplementation((_options, task) => task({ report: jest.fn() }, {} as vscode.CancellationToken));
-    (sync as jest.Mock).mockReturnValue({ status: 0 });
   });
 
   afterEach(() => {
@@ -60,15 +79,33 @@ describe('registerOpenAgentInOrgCommand', () => {
     expect(progressSpy).toHaveBeenCalled();
     expect(projectSpy).toHaveBeenCalled();
     expect(quickPickSpy).toHaveBeenCalledWith(['Agent1', 'Agent2'], { placeHolder: 'Agent name (type to search)' });
-    expect(sync).toHaveBeenCalledWith('sf', ['org', 'open', 'agent', '--api-name', [{ title: 'Agent1' }]]);
+    expect(configAggregatorSpy).toHaveBeenCalled();
+    expect(mockConfigAggregator.getPropertyValue).toHaveBeenCalledWith('target-org');
+    expect(orgCreateSpy).toHaveBeenCalledWith(expect.objectContaining({ aliasOrUsername: expect.any(String) }));
+    expect(mockConnection.singleRecordQuery).toHaveBeenCalledWith(
+      "SELECT Id FROM BotDefinition WHERE DeveloperName='Agent1'",
+      { tooling: false }
+    );
+    expect(mockOrg.getFrontDoorUrl).toHaveBeenCalledWith('AiCopilot/copilotStudio.app#/copilot/builder?copilotId=0XxD60000004Cj2KAE');
+    expect(openExternalSpy).toHaveBeenCalledWith('https://test.salesforce.com/secur/frontdoor.jsp?otp=xxx&startURL=yyy');
   });
 
-  it('shows error message when command fails', async () => {
-    (sync as jest.Mock).mockReturnValue({ status: 1, stderr: Buffer.from('Error opening agent') });
+  it('shows error message when agent not found in org', async () => {
+    mockConnection.singleRecordQuery.mockResolvedValue({ Id: null });
     registerOpenAgentInOrgCommand();
     await commandSpy.mock.calls[0][1]();
 
-    expect(errorMessageSpy).toHaveBeenCalledWith('Unable to open agent: Error opening agent');
+    expect(errorMessageSpy).toHaveBeenCalledWith('Agent "Agent1" not found in org.');
+    expect(fakeTelemetryInstance.sendException).toHaveBeenCalledWith('agent_not_found', 'Agent "Agent1" not found in org');
+  });
+
+  it('shows error message when opening agent fails', async () => {
+    mockOrg.getFrontDoorUrl.mockRejectedValue(new Error('Connection error'));
+    registerOpenAgentInOrgCommand();
+    await commandSpy.mock.calls[0][1]();
+
+    expect(errorMessageSpy).toHaveBeenCalledWith('Unable to open agent: Connection error');
+    expect(fakeTelemetryInstance.sendException).toHaveBeenCalledWith('open_agent_failed', 'Connection error');
   });
 
   it('handles error when getting agent name from path', async () => {
@@ -116,15 +153,21 @@ describe('registerOpenAgentInOrgCommand', () => {
   });
 
   it('uses agent name from path when uri is provided', async () => {
-    jest.spyOn(agentUtils, 'getAgentNameFromPath').mockResolvedValue('AgentFromPath');
+    jest.spyOn(agentUtils, 'getAgentNameFromPath').mockResolvedValue('Agent2');
+    mockConnection.singleRecordQuery.mockResolvedValue({ Id: '0XxD60000004Cj3KAE' });
 
-    const mockUri = { fsPath: '/path/to/AgentFromPath.agent' } as vscode.Uri;
+    const mockUri = { fsPath: '/path/to/Agent2.bot-meta.xml' } as vscode.Uri;
 
     registerOpenAgentInOrgCommand();
     await commandSpy.mock.calls[0][1](mockUri);
 
-    expect(agentUtils.getAgentNameFromPath).toHaveBeenCalledWith('/path/to/AgentFromPath.agent');
+    expect(agentUtils.getAgentNameFromPath).toHaveBeenCalledWith('/path/to/Agent2.bot-meta.xml');
     expect(quickPickSpy).not.toHaveBeenCalled(); // Should not show picker
-    expect(sync).toHaveBeenCalledWith('sf', ['org', 'open', 'agent', '--api-name', 'AgentFromPath']);
+    expect(mockConnection.singleRecordQuery).toHaveBeenCalledWith(
+      "SELECT Id FROM BotDefinition WHERE DeveloperName='Agent2'",
+      { tooling: false }
+    );
+    expect(mockOrg.getFrontDoorUrl).toHaveBeenCalledWith('AiCopilot/copilotStudio.app#/copilot/builder?copilotId=0XxD60000004Cj3KAE');
+    expect(openExternalSpy).toHaveBeenCalled();
   });
 });

--- a/test/commands/openAuthoringBundleInOrg.test.ts
+++ b/test/commands/openAuthoringBundleInOrg.test.ts
@@ -1,0 +1,128 @@
+import * as vscode from 'vscode';
+import { registerOpenAuthoringBundleInOrgCommand } from '../../src/commands/openAuthoringBundleInOrg';
+import { Commands } from '../../src/enums/commands';
+import { SfProject, ConfigAggregator, Org } from '@salesforce/core';
+import { CoreExtensionService } from '../../src/services/coreExtensionService';
+import { Agent } from '@salesforce/agents';
+import * as agentUtils from '../../src/commands/agentUtils';
+
+describe('registerOpenAuthoringBundleInOrgCommand', () => {
+  let commandSpy: jest.SpyInstance;
+  let projectSpy: jest.SpyInstance;
+  let quickPickSpy: jest.SpyInstance;
+  let progressSpy: jest.SpyInstance;
+  let errorMessageSpy: jest.SpyInstance;
+  let openExternalSpy: jest.SpyInstance;
+  let configAggregatorSpy: jest.SpyInstance;
+  let orgCreateSpy: jest.SpyInstance;
+
+  const fakeTelemetryInstance: any = {
+    sendException: jest.fn(),
+    sendCommandEvent: jest.fn()
+  };
+  const fakeChannelService: any = {
+    appendLine: jest.fn(),
+    showChannelOutput: jest.fn(),
+    clear: jest.fn()
+  };
+  let mockConnection: any;
+  let mockConfigAggregator: any;
+  let mockOrg: any;
+
+  beforeEach(() => {
+    // Reset mocks
+    mockConnection = {
+      instanceUrl: 'https://test.salesforce.com'
+    };
+    mockConfigAggregator = {
+      getPropertyValue: jest.fn().mockReturnValue('test-org')
+    };
+    mockOrg = {
+      getConnection: jest.fn().mockReturnValue(mockConnection),
+      getFrontDoorUrl: jest.fn().mockResolvedValue('https://test.salesforce.com/secur/frontdoor.jsp?otp=xxx&startURL=yyy')
+    };
+
+    jest.spyOn(CoreExtensionService, 'getTelemetryService').mockReturnValue(fakeTelemetryInstance);
+    jest.spyOn(CoreExtensionService, 'getChannelService').mockReturnValue(fakeChannelService);
+
+    configAggregatorSpy = jest.spyOn(ConfigAggregator, 'create').mockResolvedValue(mockConfigAggregator as any);
+    orgCreateSpy = jest.spyOn(Org, 'create').mockResolvedValue(mockOrg as any);
+
+    jest.spyOn(Agent, 'list').mockResolvedValue(['Agent1', 'Agent2']);
+
+    commandSpy = jest.spyOn(vscode.commands, 'registerCommand');
+    projectSpy = jest.spyOn(SfProject, 'getInstance').mockReturnValue({
+      getDefaultPackage: jest.fn().mockReturnValue({ fullPath: '/fake/path' })
+    } as unknown as SfProject);
+    quickPickSpy = jest.spyOn(vscode.window, 'showQuickPick').mockResolvedValue('Agent1' as any);
+    errorMessageSpy = jest.spyOn(vscode.window, 'showErrorMessage').mockImplementation();
+    openExternalSpy = jest.spyOn(vscode.env, 'openExternal').mockResolvedValue(true);
+    progressSpy = jest
+      .spyOn(vscode.window, 'withProgress')
+      .mockImplementation((_options, task) => task({ report: jest.fn() }, {} as vscode.CancellationToken));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('registers the command', () => {
+    registerOpenAuthoringBundleInOrgCommand();
+    expect(commandSpy).toHaveBeenCalledWith(Commands.openAuthoringBundleInOrg, expect.any(Function));
+  });
+
+  it('opens selected agent authoring bundle in org', async () => {
+    registerOpenAuthoringBundleInOrgCommand();
+    await commandSpy.mock.calls[0][1]();
+
+    expect(progressSpy).toHaveBeenCalled();
+    expect(projectSpy).toHaveBeenCalled();
+    expect(quickPickSpy).toHaveBeenCalledWith(['Agent1', 'Agent2'], { placeHolder: 'Agent name (type to search)' });
+    expect(configAggregatorSpy).toHaveBeenCalled();
+    expect(mockOrg.getFrontDoorUrl).toHaveBeenCalledWith('AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=Agent1');
+    expect(openExternalSpy).toHaveBeenCalledWith('https://test.salesforce.com/secur/frontdoor.jsp?otp=xxx&startURL=yyy');
+  });
+
+  it('shows error message when opening agent fails', async () => {
+    mockOrg.getFrontDoorUrl.mockRejectedValue(new Error('Connection error'));
+    registerOpenAuthoringBundleInOrgCommand();
+    await commandSpy.mock.calls[0][1]();
+
+    expect(errorMessageSpy).toHaveBeenCalledWith('Unable to open agent: Connection error');
+    expect(fakeTelemetryInstance.sendException).toHaveBeenCalledWith('open_agent_authoring_failed', 'Connection error');
+  });
+
+  it('uses agent name from path when uri is provided', async () => {
+    jest.spyOn(agentUtils, 'getAgentNameFromPath').mockResolvedValue('MyAgent');
+
+    const mockUri = { fsPath: '/path/to/aiAuthoringBundles/MyAgent/MyAgent.agent' } as vscode.Uri;
+
+    registerOpenAuthoringBundleInOrgCommand();
+    await commandSpy.mock.calls[0][1](mockUri);
+
+    expect(agentUtils.getAgentNameFromPath).toHaveBeenCalledWith('/path/to/aiAuthoringBundles/MyAgent/MyAgent.agent');
+    expect(quickPickSpy).not.toHaveBeenCalled();
+    expect(mockOrg.getFrontDoorUrl).toHaveBeenCalledWith('AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=MyAgent');
+    expect(openExternalSpy).toHaveBeenCalled();
+  });
+
+  it('shows error when no agents found in project', async () => {
+    jest.spyOn(Agent, 'list').mockResolvedValue([]);
+
+    registerOpenAuthoringBundleInOrgCommand();
+    await commandSpy.mock.calls[0][1]();
+
+    expect(errorMessageSpy).toHaveBeenCalledWith("Couldn't find any agents in the current DX project.");
+    expect(progressSpy).not.toHaveBeenCalled();
+  });
+
+  it('handles user canceling agent selection', async () => {
+    quickPickSpy.mockResolvedValue(undefined);
+
+    registerOpenAuthoringBundleInOrgCommand();
+    await commandSpy.mock.calls[0][1]();
+
+    expect(fakeTelemetryInstance.sendException).toHaveBeenCalledWith('no_agent_selected', 'No Agent selected');
+    expect(progressSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
DO NOT MERGE

until the URL changes have been released globally

OR

with this implementation, it redirects to the agents list page, same as `org open authoring-bundle` does right now.
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
adds command to open AAB to NGA builder
removes CLI dependency for opening AAB/BOT
uses VSC native org-opening mechanism

### What issues does this PR fix or reference?

 @W-21858127@

### Functionality Before

CLI required
no way to open AAB to builder

### Functionality After

no CLI required
AAB open option

### Testing Setup Notes

have AAB metadata locally, and in org, right click, see `AFDX: Open in org`
uninstall CLI, still see it work