### PR TITLE
chore: add debug workflow to identify token owner

### DIFF
--- a/.github/workflows/debug-token-owner.yml
+++ b/.github/workflows/debug-token-owner.yml
@@ -1,0 +1,32 @@
+name: Debug Token Owner
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  identify-token:
+    name: Identify IDEE_GH_TOKEN Owner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token owner
+        env:
+          GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+        run: |
+          echo "====================================="
+          echo "Identifying IDEE_GH_TOKEN owner..."
+          echo "====================================="
+          TOKEN_OWNER=$(gh api user --jq '.login')
+          echo ""
+          echo "✅ Token owner: $TOKEN_OWNER"
+          echo ""
+          echo "This account must be added to the branch protection bypass list."
+          echo "Current bypass list includes: svc-idee-bot"
+          echo ""
+          if [ "$TOKEN_OWNER" != "svc-idee-bot" ]; then
+            echo "⚠️  WARNING: Token owner ($TOKEN_OWNER) does not match svc-idee-bot!"
+            echo "   Add $TOKEN_OWNER to Settings → Branches → main → Bypass list"
+          else
+            echo "✅ Token owner matches the bypass list"
+          fi
+          echo "====================================="

--- a/.github/workflows/debug-token-permissions.yml
+++ b/.github/workflows/debug-token-permissions.yml
@@ -1,0 +1,52 @@
+name: Debug Token Permissions
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  check-permissions:
+    name: Check IDEE_GH_TOKEN Permissions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token permissions
+        env:
+          GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+        run: |
+          echo "====================================="
+          echo "Checking IDEE_GH_TOKEN permissions..."
+          echo "====================================="
+          echo ""
+
+          # Get token owner
+          TOKEN_OWNER=$(gh api user --jq '.login')
+          echo "Token owner: $TOKEN_OWNER"
+          echo ""
+
+          # Check repo permissions
+          echo "Checking repository permissions..."
+          REPO_PERMS=$(gh api /repos/forcedotcom/vscode-agents --jq '{permissions}')
+          echo "Repository permissions: $REPO_PERMS"
+          echo ""
+
+          # Check if token can push
+          CAN_PUSH=$(gh api /repos/forcedotcom/vscode-agents --jq '.permissions.push')
+          CAN_ADMIN=$(gh api /repos/forcedotcom/vscode-agents --jq '.permissions.admin')
+
+          echo "Can push: $CAN_PUSH"
+          echo "Is admin: $CAN_ADMIN"
+          echo ""
+
+          # Check token scopes (for classic PATs)
+          echo "Checking token metadata..."
+          gh api /user --include 2>&1 | grep -i "x-oauth-scopes" || echo "Cannot determine token scopes (might be fine-grained PAT)"
+          echo ""
+
+          if [ "$CAN_PUSH" != "true" ]; then
+            echo "❌ ERROR: Token does not have push permissions!"
+            echo "   The svc-idee-bot account needs write access to this repository."
+            exit 1
+          else
+            echo "✅ Token has push permissions"
+          fi
+          echo "====================================="


### PR DESCRIPTION
This debug workflow will identify which GitHub account owns the `IDEE_GH_TOKEN` secret.

**Purpose**: The automated release workflow is failing because the token owner is not in the branch protection bypass list. This workflow will show us which account we need to add.

**Usage**: 
- Runs automatically on PR open/update
- Can also be triggered manually via workflow_dispatch

Check the Actions tab to see the token owner after this PR is opened.