### PR TITLE
fix: recover from session start failures in the AFDX agent preview @W-22434854@

### DIFF
--- a/src/views/agentCombined/handlers/webviewMessageHandlers.ts
+++ b/src/views/agentCombined/handlers/webviewMessageHandlers.ts
@@ -90,8 +90,8 @@ export class WebviewMessageHandlers {
     if (this.state.agentInstance || this.state.isSessionActive) {
       this.state.clearSessionState();
       await this.state.setSessionActive(false);
-      await this.state.setSessionStarting(false);
     }
+    await this.state.setSessionStarting(false);
 
     // Check for specific agent deactivation error
     if (

--- a/src/views/agentCombined/handlers/webviewMessageHandlers.ts
+++ b/src/views/agentCombined/handlers/webviewMessageHandlers.ts
@@ -93,29 +93,29 @@ export class WebviewMessageHandlers {
     }
     await this.state.setSessionStarting(false);
 
-    // Check for specific agent deactivation error
+    const genericTitle = 'Something went wrong';
+
     if (
       originalErrorMessage.includes('404') &&
       originalErrorMessage.includes('NOT_FOUND') &&
       originalErrorMessage.includes('No valid version available')
     ) {
       await this.messageSender.sendError(
-        'This agent is currently deactivated, so you can\'t converse with it.  Activate the agent using either the "AFDX: Activate Agent" VS Code command or your org\'s Agentforce UI.',
-        originalErrorMessage
+        genericTitle,
+        'This agent is currently deactivated, so you can\'t converse with it. Activate the agent using either the "AFDX: Activate Agent" VS Code command or your org\'s Agentforce UI.'
       );
     } else if (originalErrorMessage.includes('NOT_FOUND') && originalErrorMessage.includes('404')) {
       await this.messageSender.sendError(
-        "The selected agent couldn't be found. Either it's been deleted or you don't have access to it.",
-        originalErrorMessage
+        genericTitle,
+        "The selected agent couldn't be found. Either it's been deleted or you don't have access to it."
       );
     } else if (originalErrorMessage.includes('403') || originalErrorMessage.includes('FORBIDDEN')) {
       await this.messageSender.sendError(
-        "You don't have permission to use this agent. Consult your Salesforce administrator.",
-        originalErrorMessage
+        genericTitle,
+        "You don't have permission to use this agent. Consult your Salesforce administrator."
       );
     } else {
-      // For unknown errors, show generic message with technical details
-      await this.messageSender.sendError('Something went wrong. Please try again.', originalErrorMessage);
+      await this.messageSender.sendError(genericTitle, originalErrorMessage);
     }
 
     await this.state.setResetAgentViewAvailable(true);

--- a/src/views/agentCombined/handlers/webviewMessageHandlers.ts
+++ b/src/views/agentCombined/handlers/webviewMessageHandlers.ts
@@ -93,29 +93,27 @@ export class WebviewMessageHandlers {
     }
     await this.state.setSessionStarting(false);
 
-    const genericTitle = 'Something went wrong';
-
     if (
       originalErrorMessage.includes('404') &&
       originalErrorMessage.includes('NOT_FOUND') &&
       originalErrorMessage.includes('No valid version available')
     ) {
       await this.messageSender.sendError(
-        genericTitle,
-        'This agent is currently deactivated, so you can\'t converse with it. Activate the agent using either the "AFDX: Activate Agent" VS Code command or your org\'s Agentforce UI.'
+        'Agent deactivated',
+        'This agent is currently deactivated, so you can\'t converse with it. Activate it using the "AFDX: Activate Agent" command or your org\'s Agentforce UI.'
       );
     } else if (originalErrorMessage.includes('NOT_FOUND') && originalErrorMessage.includes('404')) {
       await this.messageSender.sendError(
-        genericTitle,
+        'Agent not found',
         "The selected agent couldn't be found. Either it's been deleted or you don't have access to it."
       );
     } else if (originalErrorMessage.includes('403') || originalErrorMessage.includes('FORBIDDEN')) {
       await this.messageSender.sendError(
-        genericTitle,
+        'Permission denied',
         "You don't have permission to use this agent. Consult your Salesforce administrator."
       );
     } else {
-      await this.messageSender.sendError(genericTitle, originalErrorMessage);
+      await this.messageSender.sendError('Something went wrong', originalErrorMessage);
     }
 
     await this.state.setResetAgentViewAvailable(true);

--- a/test/views/agentCombined/handlers/webviewMessageHandlers.test.ts
+++ b/test/views/agentCombined/handlers/webviewMessageHandlers.test.ts
@@ -165,7 +165,7 @@ describe('WebviewMessageHandlers', () => {
       await handlers.handleError(error);
 
       expect(mockMessageSender.sendError).toHaveBeenCalledWith(
-        'Something went wrong',
+        'Agent deactivated',
         expect.stringContaining('currently deactivated')
       );
     });
@@ -176,7 +176,7 @@ describe('WebviewMessageHandlers', () => {
       await handlers.handleError(error);
 
       expect(mockMessageSender.sendError).toHaveBeenCalledWith(
-        'Something went wrong',
+        'Agent not found',
         expect.stringContaining("couldn't be found")
       );
     });
@@ -187,7 +187,7 @@ describe('WebviewMessageHandlers', () => {
       await handlers.handleError(error);
 
       expect(mockMessageSender.sendError).toHaveBeenCalledWith(
-        'Something went wrong',
+        'Permission denied',
         expect.stringContaining("don't have permission")
       );
     });

--- a/test/views/agentCombined/handlers/webviewMessageHandlers.test.ts
+++ b/test/views/agentCombined/handlers/webviewMessageHandlers.test.ts
@@ -165,8 +165,8 @@ describe('WebviewMessageHandlers', () => {
       await handlers.handleError(error);
 
       expect(mockMessageSender.sendError).toHaveBeenCalledWith(
-        expect.stringContaining('currently deactivated'),
-        '404 NOT_FOUND: No valid version available for this agent'
+        'Something went wrong',
+        expect.stringContaining('currently deactivated')
       );
     });
 
@@ -176,8 +176,8 @@ describe('WebviewMessageHandlers', () => {
       await handlers.handleError(error);
 
       expect(mockMessageSender.sendError).toHaveBeenCalledWith(
-        expect.stringContaining("couldn't be found"),
-        '404 NOT_FOUND: Agent does not exist'
+        'Something went wrong',
+        expect.stringContaining("couldn't be found")
       );
     });
 
@@ -187,8 +187,8 @@ describe('WebviewMessageHandlers', () => {
       await handlers.handleError(error);
 
       expect(mockMessageSender.sendError).toHaveBeenCalledWith(
-        expect.stringContaining("don't have permission"),
-        '403 FORBIDDEN: Access denied'
+        'Something went wrong',
+        expect.stringContaining("don't have permission")
       );
     });
 
@@ -198,7 +198,7 @@ describe('WebviewMessageHandlers', () => {
       await handlers.handleError(error);
 
       expect(mockMessageSender.sendError).toHaveBeenCalledWith(
-        'Something went wrong. Please try again.',
+        'Something went wrong',
         'Something unexpected happened'
       );
     });

--- a/test/webview/AgentPreview.messages.test.tsx
+++ b/test/webview/AgentPreview.messages.test.tsx
@@ -83,13 +83,15 @@ describe('AgentPreview - Message Handlers', () => {
     it('should handle compilationError with custom message', async () => {
       renderComponent();
       handlers.get('compilationError')?.({ message: 'Syntax error' });
-      await waitFor(() => expect(screen.getByText('Syntax error')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('Something went wrong')).toBeInTheDocument());
+      expect(screen.getByText('Syntax error')).toBeInTheDocument();
     });
 
     it('should handle compilationError with default message', async () => {
       renderComponent();
       handlers.get('compilationError')?.({});
-      await waitFor(() => expect(screen.getByText('Failed to compile the agent.')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('Something went wrong')).toBeInTheDocument());
+      expect(screen.getByText('Failed to compile the agent.')).toBeInTheDocument();
     });
   });
 

--- a/test/webview/AgentPreview.messages.test.tsx
+++ b/test/webview/AgentPreview.messages.test.tsx
@@ -83,14 +83,14 @@ describe('AgentPreview - Message Handlers', () => {
     it('should handle compilationError with custom message', async () => {
       renderComponent();
       handlers.get('compilationError')?.({ message: 'Syntax error' });
-      await waitFor(() => expect(screen.getByText('Something went wrong')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('Compilation failed')).toBeInTheDocument());
       expect(screen.getByText('Syntax error')).toBeInTheDocument();
     });
 
     it('should handle compilationError with default message', async () => {
       renderComponent();
       handlers.get('compilationError')?.({});
-      await waitFor(() => expect(screen.getByText('Something went wrong')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('Compilation failed')).toBeInTheDocument());
       expect(screen.getByText('Failed to compile the agent.')).toBeInTheDocument();
     });
   });

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -383,25 +383,23 @@ const App: React.FC = () => {
 
   return (
     <div className="app">
-      {!hasSessionError && (
-        <div className="app-menu">
-          <AgentSelector
-            selectedAgent={desiredAgentId}
-            onAgentChange={handleAgentChange}
-            isSessionActive={isSessionActive}
-            isSessionStarting={isSessionStarting}
-            onLiveModeChange={handleLiveModeChange}
-            initialLiveMode={isLiveMode}
-            onSelectedAgentInfoChange={setSelectedAgentInfo}
-            onStopSession={handleStopSession}
-            onAgentsAvailabilityChange={handleAgentsAvailabilityChange}
-          />
-          <div className="app-menu-divider" />
-          {previewAgentId !== '' && !isSessionStarting && (
-            <TabNavigation activeTab={activeTab} onTabChange={handleTabChange} showTracerTab={selectedAgentInfo?.type !== AgentSource.PUBLISHED} />
-          )}
-        </div>
-      )}
+      <div className="app-menu" style={hasSessionError ? { display: 'none' } : undefined}>
+        <AgentSelector
+          selectedAgent={desiredAgentId}
+          onAgentChange={handleAgentChange}
+          isSessionActive={isSessionActive}
+          isSessionStarting={isSessionStarting}
+          onLiveModeChange={handleLiveModeChange}
+          initialLiveMode={isLiveMode}
+          onSelectedAgentInfoChange={setSelectedAgentInfo}
+          onStopSession={handleStopSession}
+          onAgentsAvailabilityChange={handleAgentsAvailabilityChange}
+        />
+        <div className="app-menu-divider" />
+        {previewAgentId !== '' && !isSessionStarting && (
+          <TabNavigation activeTab={activeTab} onTabChange={handleTabChange} showTracerTab={selectedAgentInfo?.type !== AgentSource.PUBLISHED} />
+        )}
+      </div>
       <div className="app-content">
         <div className={`tab-content ${activeTab === 'preview' ? 'active' : 'hidden'}`}>
           <AgentPreview

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -82,6 +82,9 @@ const App: React.FC = () => {
     const disposeRefreshAgents = vscodeApi.onMessage('refreshAgents', () => {
       // Switch back to preview tab when refreshing agents
       setActiveTab('preview');
+      sessionActiveRef.current = false;
+      setIsSessionActive(false);
+      setIsSessionStarting(false);
     });
 
     const disposeSetLiveMode = vscodeApi.onMessage('setLiveMode', (data: { isLiveMode: boolean }) => {
@@ -251,11 +254,27 @@ const App: React.FC = () => {
       }
     });
 
+    const disposeCompilationError = vscodeApi.onMessage('compilationError', () => {
+      sessionActiveRef.current = false;
+      setIsSessionActive(false);
+      setIsSessionStarting(false);
+      const startResolver = sessionStartResolversRef.current.shift();
+      if (startResolver) {
+        startResolver(false);
+      }
+    });
+
+    const disposeClearMessages = vscodeApi.onMessage('clearMessages', () => {
+      setIsSessionStarting(false);
+    });
+
     return () => {
       disposeSessionStarted();
       disposeSessionEnded();
       disposeSessionStarting();
       disposeSessionError();
+      disposeCompilationError();
+      disposeClearMessages();
     };
   }, []);
 

--- a/webview/src/components/AgentPreview/AgentPreview.css
+++ b/webview/src/components/AgentPreview/AgentPreview.css
@@ -55,6 +55,7 @@ body.vscode-high-contrast .agent-preview-error-icon {
   font-weight: 500;
   line-height: 1.3;
   text-wrap: balance;
+  white-space: pre-wrap;
 }
 
 .agent-preview-error .vscode-button {

--- a/webview/src/components/AgentPreview/AgentPreview.tsx
+++ b/webview/src/components/AgentPreview/AgentPreview.tsx
@@ -268,15 +268,13 @@ const AgentPreview = forwardRef<AgentPreviewRef, AgentPreviewProps>(
       const disposeCompilationError = vscodeApi.onMessage('compilationError', data => {
         setIsLoading(false);
         setAgentConnected(false);
-
-        const errorMessage: Message = {
-          id: Date.now().toString(),
-          type: 'system',
-          content: data?.message || 'Failed to compile the agent.',
-          systemType: 'error',
-          timestamp: new Date().toISOString()
-        };
-        setMessages(prev => [...prev, errorMessage]);
+        sessionActiveStateRef.current = false;
+        sessionErrorTimestampRef.current = Date.now();
+        setHasSessionError(true);
+        setErrorMessage('Something went wrong');
+        setErrorDetails(data?.message || 'Failed to compile the agent.');
+        setMessages(prev => pruneStartingSessionMessages(prev));
+        onSessionTransitionSettled();
       });
       disposers.push(disposeCompilationError);
 
@@ -312,7 +310,7 @@ const AgentPreview = forwardRef<AgentPreviewRef, AgentPreviewProps>(
         sessionActiveStateRef.current = false;
         sessionErrorTimestampRef.current = Date.now();
         setHasSessionError(true);
-        setErrorMessage(data?.message || 'Something went wrong. Please try again.');
+        setErrorMessage(data?.message || 'Something went wrong');
         setErrorDetails(data?.details);
         setMessages(prev => pruneStartingSessionMessages(prev));
         setIsLoading(false);

--- a/webview/src/components/AgentPreview/AgentPreview.tsx
+++ b/webview/src/components/AgentPreview/AgentPreview.tsx
@@ -271,7 +271,7 @@ const AgentPreview = forwardRef<AgentPreviewRef, AgentPreviewProps>(
         sessionActiveStateRef.current = false;
         sessionErrorTimestampRef.current = Date.now();
         setHasSessionError(true);
-        setErrorMessage('Something went wrong');
+        setErrorMessage('Compilation failed');
         setErrorDetails(data?.message || 'Failed to compile the agent.');
         setMessages(prev => pruneStartingSessionMessages(prev));
         onSessionTransitionSettled();


### PR DESCRIPTION
### What does this PR do?

Fixes recovery from session start failures in the AFDX agent preview.

- Title-bar Refresh and Reset (clear-all) icons no longer get stuck after a session start failure. The webview's `isSessionStarting` and the `agentforceDX:sessionStarting` context flag are cleared on `error`, `compilationError`, `clearMessages`, and `refreshAgents`.
- Compilation errors now render the same error screen as other failures (icon + bold title + muted subtitle + Go Back button) instead of plain text inside the chat transcript.
- Error titles are short and distinct: "Agent deactivated", "Agent not found", "Permission denied", "Compilation failed", "Something went wrong". The subtitle holds the human-readable explanation for known cases or the raw server error for the generic case.
- The agent selector stays mounted while the error screen is showing, so clicking Go Back returns to a populated dropdown with controls enabled.
- Multi-line compiler output is preserved in the subtitle (`white-space: pre-wrap`).

### What issues does this PR fix or reference?

@W-22434854@

### Functionality Before

- Compilation errors showed as a centered system message with no recovery affordance.
- Other failure types used full-paragraph bold titles, with the raw server error string shown as the subtitle.
- After clicking Go Back from the error screen, the dropdown briefly re-loaded and the top start button stayed disabled because the selector remounted from scratch.
- The title-bar Refresh and Reset icons stayed hidden after early session-start failures.

### Functionality After

- All failure types render the same error screen with short titles and explanatory subtitles.
- Refresh and Reset icons are reachable from the error screen and recover the view to a usable state.
- Clicking Go Back keeps the agent selector populated and its controls enabled.
- Compilation error subtitles render multi-line compiler output correctly.

### Testing Setup Notes

**Automated**

- `npm run test:backend` (381 tests) and `npm run test:frontend` (387 tests) pass. Updated assertions in `test/views/agentCombined/handlers/webviewMessageHandlers.test.ts` and `test/webview/AgentPreview.messages.test.tsx`.

**Manual verification**

1. Open an agent script project in the Extension Development Host. Select an agent that has a syntax error and click **Start Simulation**. Expected: error screen with icon, "Compilation failed" title, multi-line compiler output as subtitle, **Go Back** button. Title-bar **Refresh** and **Reset** icons are visible.
2. From step 1, click **Go Back**. Expected: returns to the agent selector with the same agent selected, dropdown not loading, top start button enabled.
3. From step 1, click the title-bar **Refresh** icon instead. Expected: agents list reloads and the view returns to the placeholder.
4. From step 1, click the title-bar **Reset** icon. Expected: clears the error and returns to the agent placeholder for the same agent.
5. Authenticate to an org and select a deactivated agent, then **Start Live Test**. Expected: title "Agent deactivated" with the activation guidance as the subtitle.
6. Repeat with a 403/permission scenario and a 404/deleted agent. Expected: titles "Permission denied" and "Agent not found" with the matching explanation.
7. Successful session start regression: select a healthy agent and **Start Simulation**. Expected: no error screen flashes; chat loads; stop and restart work.