### PR TITLE
fix: clarify empty-state message in Activate Agent picker @W-22497097@

### DIFF
--- a/src/commands/activateAgent.ts
+++ b/src/commands/activateAgent.ts
@@ -78,7 +78,10 @@ export const registerActivateAgentCommand = () => {
         const deactivated = agents.filter(a => !a.isActivated);
 
         if (deactivated.length === 0) {
-          vscode.window.showInformationMessage('No deactivated agents found in the org.');
+          const msg = agents.length === 0
+            ? 'No published agents found in the org.'
+            : 'No published agents are available to activate.';
+          vscode.window.showInformationMessage(msg);
           return;
         }
 

--- a/test/commands/activateAgent.test.ts
+++ b/test/commands/activateAgent.test.ts
@@ -151,14 +151,14 @@ describe('activateAgent command', () => {
     );
   });
 
-  it('shows message when no deactivated agents found', async () => {
+  it('shows message when no agents exist in the org', async () => {
     setupOrgMocks();
     (getPublishedAgents as jest.Mock).mockResolvedValue([]);
 
     const handler = registerAndGetHandler();
     await handler();
 
-    expect(infoSpy).toHaveBeenCalledWith('No deactivated agents found in the org.');
+    expect(infoSpy).toHaveBeenCalledWith('No published agents found in the org.');
   });
 
   it('shows message when only active agents exist', async () => {
@@ -170,7 +170,7 @@ describe('activateAgent command', () => {
     const handler = registerAndGetHandler();
     await handler();
 
-    expect(infoSpy).toHaveBeenCalledWith('No deactivated agents found in the org.');
+    expect(infoSpy).toHaveBeenCalledWith('No published agents are available to activate.');
     expect(quickPickSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
### Summary

@W-22497097@

The Command Palette "SFDX: Activate Agent" picker reported "No deactivated agents found in the org." even when freshly published agents (with only an Inactive v1, never previously Active) were eligible to activate. The filter logic was already correct (an agent is activatable when it has no version with `Status === 'Active'`, matching `@salesforce/plugin-agent` `src/agentActivation.ts:52-70`); only the empty-state message wording was misleading.

### Before

Picker shows "No deactivated agents found in the org." regardless of why no agents are eligible — even when fresh-publish Inactive agents should appear, and when all agents are simply already active.

### After

Two accurate messages:
- No agents at all in the org → "No published agents found in the org."
- Agents exist but all have an Active version → "No published agents are available to activate."

(The picker itself was always correctly listing fresh-publish Inactive agents; the broken piece was the wording shown when nothing matched.)

### Testing

**Automated**

```bash
npx jest test/commands/activateAgent.test.ts
```

Expected: 14 passed. Covers the new "no agents in org" and "all already active" branches plus the existing fresh-publish/Inactive picker behavior.

**Manual**

1. Against an org with at least one published agent whose only version is Inactive (never Active): in VS Code, run Command Palette → `SFDX: Activate Agent`. Expected: the agent appears in the picker; selecting it lets you choose a version and activates it.
2. Against an org where every published agent has an Active version: run `SFDX: Activate Agent`. Expected: info toast `No published agents are available to activate.`
3. Against an org with no published agents: run `SFDX: Activate Agent`. Expected: info toast `No published agents found in the org.`